### PR TITLE
Remove superfluous apostrophes

### DIFF
--- a/web/index.dust
+++ b/web/index.dust
@@ -204,7 +204,7 @@
 			<li>timeshifted purple</li>
 		</ul>
 		<p><br>
-		Note that the 'Time Spiral "Timeshifted"' set does not have a booster field. This 'set' was actually a subset of the 'Time Spiral' set and it's cards are the 'timeshifted purple' booster card type mentioned above.<br>
+		Note that the 'Time Spiral "Timeshifted"' set does not have a booster field. This 'set' was actually a subset of the 'Time Spiral' set and its cards are the 'timeshifted purple' booster card type mentioned above.<br>
 		<br>
 		The "Magic: The Gathering—Conspiracy" expansion has an additional "draft-matters" type which can either be a "Conspiracy" type card or a card that affects drafting.<br>
 		<br>
@@ -242,7 +242,7 @@
 				<tr>
 					<td>name</td>
 					<td>"Research"</td>
-					<td>The card name. For split, double-faced and flip cards, just the name of one side of the card. Basically each 'sub-card' has it's own record.</td>
+					<td>The card name. For split, double-faced and flip cards, just the name of one side of the card. Basically each 'sub-card' has its own record.</td>
 				</tr>
 				<tr>
 					<td>names</td>
@@ -282,7 +282,7 @@
 				<tr>
 					<td>subtypes</td>
 					<td>[ "Angel" ]</td>
-					<td>The subtypes of the card. These appear to the right of the dash in a card type. Usually each word is it's own subtype. Example values: Trap, Arcane, Equipment, Aura, Human, Rat, Squirrel, etc.</td>
+					<td>The subtypes of the card. These appear to the right of the dash in a card type. Usually each word is its own subtype. Example values: Trap, Arcane, Equipment, Aura, Human, Rat, Squirrel, etc.</td>
 				</tr>
 				<tr>
 					<td>rarity</td>


### PR DESCRIPTION
Remove superfluous apostrophes for extra professionalism.
"it's" -> "its"
