### PR TITLE
Fixed 2016 changelog dates

### DIFF
--- a/web/changelog.json
+++ b/web/changelog.json
@@ -1,7 +1,7 @@
 [
 	{
 		"version": "3.3.9",
-		"when": "2015-01-22",
+		"when": "2016-01-22",
 		"changes": [
 			"OGW legalities",
 			"Fixed some leftovers of adding {X} mana."
@@ -10,7 +10,7 @@
 	},
 	{
 		"version": "3.3.8",
-		"when": "2015-01-13",
+		"when": "2016-01-13",
 		"changes": [
 			"OGW Initial version (note that OGW is not yet valid on standard format. Legalities will still be re-updated on the 22nd).",
 			"New {C} mana symbol.",


### PR DESCRIPTION
Hey, I'm working on something using mtgjson.com (thanks!) at the moment and noticed that these dates in the changelog were wrong. Perhaps it would be better to just add new objects to the changelog rather than modifying existing ones, but I'll leave that up to you.