### PR TITLE
update sets that contain madness text

### DIFF
--- a/json/DD3_GVL.json
+++ b/json/DD3_GVL.json
@@ -26,10 +26,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -39,18 +35,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -79,55 +63,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don't have to be tapped."
+          "text": "The first ability can target any two lands. They don’t have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are permanents. You can cast one at the time you could cast a sorcery. When your planeswalker spell resolves, it enters the battlefield under your control."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are not creatures. Spells and abilities that affect creatures won’t affect them."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers have loyalty. A planeswalker enters the battlefield with a number of loyalty counters on it equal to the number printed in its lower right corner. Activating one of its abilities may cause it to gain or lose loyalty counters. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it. If it has no loyalty counters on it, it’s put into its owner’s graveyard as a state-based action."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers each have a number of activated abilities called “loyalty abilities.” You can activate a loyalty ability of a planeswalker you control only at the time you could cast a sorcery and only if you haven’t activated one of that planeswalker’s loyalty abilities yet that turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "The cost to activate a planeswalker’s loyalty ability is represented by a symbol with a number inside. Up-arrows contain positive numbers, such as “+1”; this means “Put one loyalty counter on this planeswalker.” Down-arrows contain negative numbers, such as “-7”; this means “Remove seven loyalty counters from this planeswalker.” A symbol with a “0” means “Put zero loyalty counters on this planeswalker.”"
-        },
-        {
-          "date": "2013-07-01",
-          "text": "You can’t activate a planeswalker’s ability with a negative loyalty cost unless the planeswalker has at least that many loyalty counters on it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers can’t attack (unless an effect turns the planeswalker into a creature). However, they can be attacked. Each of your attacking creatures can attack your opponent or a planeswalker that player controls. You say which as you declare attackers."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If your planeswalkers are being attacked, you can block the attackers as normal."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a creature that’s attacking a planeswalker isn’t blocked, it’ll deal its combat damage to that planeswalker. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a source you control would deal noncombat damage to an opponent, you may have that source deal that damage to a planeswalker that opponent controls instead. For example, although you can’t target a planeswalker with Shock, you can target your opponent with Shock, and then as Shock resolves, choose to have Shock deal its 2 damage to one of your opponent’s planeswalkers. (You can’t split up that damage between different players and/or planeswalkers.) If you have Shock deal its damage to a planeswalker, two loyalty counters are removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a player controls two or more planeswalkers that share a planeswalker type, that player chooses one of them and the rest are put into their owners’ graveyards as a state-based action."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -157,27 +97,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -204,13 +128,13 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
+          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
         }
       ],
       "subtypes": [
         "Lizard"
       ],
-      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "1",
       "type": "Creature — Lizard",
       "types": [
@@ -236,18 +160,6 @@
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -303,10 +215,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -316,18 +224,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -380,27 +276,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -453,27 +333,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -523,27 +387,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -596,27 +444,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -669,10 +501,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -682,18 +510,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -719,7 +535,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
+          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
         },
         {
           "date": "2004-10-04",
@@ -756,10 +572,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -768,19 +580,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -831,27 +631,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -890,7 +674,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         }
       ],
       "subtypes": [
@@ -923,10 +707,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -936,18 +716,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -997,10 +765,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Kamigawa Block",
           "legality": "Legal"
         },
@@ -1010,18 +774,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1045,11 +797,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -1079,10 +831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -1095,19 +843,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1184,27 +920,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1236,7 +956,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
+          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
         }
       ],
       "subtypes": [
@@ -1267,10 +987,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1280,18 +996,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1315,7 +1019,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
+          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature’s power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
         },
         {
           "date": "2007-10-01",
@@ -1323,7 +1027,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites previous effects that changed the enchanted creature's creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
+          "text": "Lignify overwrites previous effects that changed the enchanted creature’s creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
         },
         {
           "date": "2007-10-01",
@@ -1331,11 +1035,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a previous effect switched the creature's power and toughness, that effect still applies (though it will apply to the creature's new power and toughness)."
+          "text": "If a previous effect switched the creature’s power and toughness, that effect still applies (though it will apply to the creature’s new power and toughness)."
         },
         {
           "date": "2007-10-01",
-          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it's applied before the creature loses the ability."
+          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it’s applied before the creature loses the ability."
         },
         {
           "date": "2007-10-01",
@@ -1343,11 +1047,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will overwrite any previous effects that set the enchanted creature's power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
+          "text": "Lignify will overwrite any previous effects that set the enchanted creature’s power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature's power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
+          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature’s power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
         }
       ],
       "subtypes": [
@@ -1380,27 +1084,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1430,7 +1118,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         },
         {
           "date": "2008-08-01",
@@ -1462,27 +1150,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1508,7 +1180,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If cast targeting an opponent's creature, you get the Elephant when that creature goes to the graveyard."
+          "text": "If cast targeting an opponent’s creature, you get the Elephant when that creature goes to the graveyard."
         }
       ],
       "subtypes": [
@@ -1538,27 +1210,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1598,10 +1254,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1610,19 +1262,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1649,7 +1289,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -1677,10 +1317,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1689,19 +1325,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1758,10 +1382,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1771,18 +1391,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1807,11 +1415,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2013-06-07",
-          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won't be affected."
+          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won’t be affected."
         }
       ],
       "text": "Choose one —\n• Untap all lands you control.\n• Until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -1838,27 +1446,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1904,10 +1496,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1920,19 +1508,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1966,7 +1542,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -1994,7 +1570,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
+          "format": "Khans of Tarkir Block",
           "legality": "Legal"
         },
         {
@@ -2003,30 +1579,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -2069,23 +1621,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2141,27 +1677,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2192,11 +1712,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -3175,10 +2695,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3188,18 +2704,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3228,51 +2732,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are permanents. You can cast one at the time you could cast a sorcery. When your planeswalker spell resolves, it enters the battlefield under your control."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are not creatures. Spells and abilities that affect creatures won’t affect them."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers have loyalty. A planeswalker enters the battlefield with a number of loyalty counters on it equal to the number printed in its lower right corner. Activating one of its abilities may cause it to gain or lose loyalty counters. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it. If it has no loyalty counters on it, it’s put into its owner’s graveyard as a state-based action."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers each have a number of activated abilities called “loyalty abilities.” You can activate a loyalty ability of a planeswalker you control only at the time you could cast a sorcery and only if you haven’t activated one of that planeswalker’s loyalty abilities yet that turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "The cost to activate a planeswalker’s loyalty ability is represented by a symbol with a number inside. Up-arrows contain positive numbers, such as “+1”; this means “Put one loyalty counter on this planeswalker.” Down-arrows contain negative numbers, such as “-7”; this means “Remove seven loyalty counters from this planeswalker.” A symbol with a “0” means “Put zero loyalty counters on this planeswalker.”"
-        },
-        {
-          "date": "2013-07-01",
-          "text": "You can’t activate a planeswalker’s ability with a negative loyalty cost unless the planeswalker has at least that many loyalty counters on it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers can’t attack (unless an effect turns the planeswalker into a creature). However, they can be attacked. Each of your attacking creatures can attack your opponent or a planeswalker that player controls. You say which as you declare attackers."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If your planeswalkers are being attacked, you can block the attackers as normal."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a creature that’s attacking a planeswalker isn’t blocked, it’ll deal its combat damage to that planeswalker. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a source you control would deal noncombat damage to an opponent, you may have that source deal that damage to a planeswalker that opponent controls instead. For example, although you can’t target a planeswalker with Shock, you can target your opponent with Shock, and then as Shock resolves, choose to have Shock deal its 2 damage to one of your opponent’s planeswalkers. (You can’t split up that damage between different players and/or planeswalkers.) If you have Shock deal its damage to a planeswalker, two loyalty counters are removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a player controls two or more planeswalkers that share a planeswalker type, that player chooses one of them and the rest are put into their owners’ graveyards as a state-based action."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "subtypes": [
@@ -3303,10 +2763,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3315,19 +2771,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3378,10 +2822,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Kamigawa Block",
           "legality": "Legal"
         },
@@ -3391,18 +2831,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3452,27 +2880,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3528,27 +2940,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3614,10 +3010,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -3627,18 +3019,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3702,10 +3082,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3714,27 +3090,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Shards of Alara Block",
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -3762,7 +3122,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
@@ -3799,10 +3159,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -3815,19 +3171,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3882,10 +3226,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3894,19 +3234,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3959,27 +3287,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4042,10 +3354,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4055,18 +3363,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4092,7 +3388,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Faerie Macabre's second ability can be activated only while it's in your hand. You can do this any time you could cast an instant."
+          "text": "Faerie Macabre’s second ability can be activated only while it’s in your hand. You can do this any time you could cast an instant."
         },
         {
           "date": "2008-05-01",
@@ -4129,27 +3425,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4201,10 +3481,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4213,19 +3489,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4275,10 +3539,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4291,19 +3551,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4332,7 +3580,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4376,10 +3624,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4388,19 +3632,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4426,7 +3658,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may pay the cost of Skeletal Vampire's activated abilities by sacrificing any Bat, not just a Bat token it created."
+          "text": "You may pay the cost of Skeletal Vampire’s activated abilities by sacrificing any Bat, not just a Bat token it created."
         }
       ],
       "subtypes": [
@@ -4458,10 +3690,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Kamigawa Block",
           "legality": "Legal"
         },
@@ -4471,18 +3699,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4506,11 +3722,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -4540,10 +3756,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4552,19 +3764,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4619,27 +3819,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4693,10 +3877,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4706,18 +3886,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4763,10 +3931,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4775,19 +3939,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4818,7 +3970,7 @@
           "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
         }
       ],
-      "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -4843,27 +3995,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4929,18 +4065,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -4983,10 +4107,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4995,19 +4115,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5038,7 +4146,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -5066,10 +4174,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5079,18 +4183,6 @@
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5116,7 +4208,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -5144,27 +4236,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5193,19 +4269,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
+          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -5233,10 +4309,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5246,18 +4318,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5301,7 +4361,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -5332,10 +4392,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5344,23 +4400,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Scars of Mirrodin Block",
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5385,11 +4429,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token's owner is the player under whose control it entered the battlefield."
+          "text": "A token’s owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -5415,23 +4459,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {

--- a/json/DDD.json
+++ b/json/DDD.json
@@ -26,10 +26,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -39,18 +35,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -79,55 +63,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first ability can target any two lands. They don't have to be tapped."
+          "text": "The first ability can target any two lands. They don’t have to be tapped."
         },
         {
           "date": "2009-10-01",
-          "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are permanents. You can cast one at the time you could cast a sorcery. When your planeswalker spell resolves, it enters the battlefield under your control."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are not creatures. Spells and abilities that affect creatures won’t affect them."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers have loyalty. A planeswalker enters the battlefield with a number of loyalty counters on it equal to the number printed in its lower right corner. Activating one of its abilities may cause it to gain or lose loyalty counters. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it. If it has no loyalty counters on it, it’s put into its owner’s graveyard as a state-based action."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers each have a number of activated abilities called “loyalty abilities.” You can activate a loyalty ability of a planeswalker you control only at the time you could cast a sorcery and only if you haven’t activated one of that planeswalker’s loyalty abilities yet that turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "The cost to activate a planeswalker’s loyalty ability is represented by a symbol with a number inside. Up-arrows contain positive numbers, such as “+1”; this means “Put one loyalty counter on this planeswalker.” Down-arrows contain negative numbers, such as “-7”; this means “Remove seven loyalty counters from this planeswalker.” A symbol with a “0” means “Put zero loyalty counters on this planeswalker.”"
-        },
-        {
-          "date": "2013-07-01",
-          "text": "You can’t activate a planeswalker’s ability with a negative loyalty cost unless the planeswalker has at least that many loyalty counters on it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers can’t attack (unless an effect turns the planeswalker into a creature). However, they can be attacked. Each of your attacking creatures can attack your opponent or a planeswalker that player controls. You say which as you declare attackers."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If your planeswalkers are being attacked, you can block the attackers as normal."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a creature that’s attacking a planeswalker isn’t blocked, it’ll deal its combat damage to that planeswalker. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a source you control would deal noncombat damage to an opponent, you may have that source deal that damage to a planeswalker that opponent controls instead. For example, although you can’t target a planeswalker with Shock, you can target your opponent with Shock, and then as Shock resolves, choose to have Shock deal its 2 damage to one of your opponent’s planeswalkers. (You can’t split up that damage between different players and/or planeswalkers.) If you have Shock deal its damage to a planeswalker, two loyalty counters are removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a player controls two or more planeswalkers that share a planeswalker type, that player chooses one of them and the rest are put into their owners’ graveyards as a state-based action."
+          "text": "The third ability affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
         }
       ],
       "subtypes": [
@@ -157,27 +97,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -204,13 +128,13 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
+          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
         }
       ],
       "subtypes": [
         "Lizard"
       ],
-      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "1",
       "type": "Creature — Lizard",
       "types": [
@@ -236,18 +160,6 @@
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -303,10 +215,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -316,18 +224,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -380,27 +276,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -453,27 +333,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -523,27 +387,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -596,27 +444,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -669,10 +501,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -682,18 +510,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -719,7 +535,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability that returns a creature doesn't target anything. You can return a creature with shroud or protection from green, for example. You don't decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
+          "text": "The ability that returns a creature doesn’t target anything. You can return a creature with shroud or protection from green, for example. You don’t decide which creature to return until the ability resolves. If you control no other green creatures, you must return Stampeding Wildebeests itself."
         },
         {
           "date": "2004-10-04",
@@ -756,10 +572,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -768,19 +580,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -831,27 +631,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -890,7 +674,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         }
       ],
       "subtypes": [
@@ -923,10 +707,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -936,18 +716,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -997,10 +765,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Kamigawa Block",
           "legality": "Legal"
         },
@@ -1010,18 +774,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1045,11 +797,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -1079,10 +831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -1095,19 +843,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1184,27 +920,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1236,7 +956,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "If the target of Rancor when it's cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner's graveyard. It won't return to its owner's hand."
+          "text": "If the target of Rancor when it’s cast as a spell is an illegal target when Rancor tries to resolve, Rancor will be countered and put into its owner’s graveyard. It won’t return to its owner’s hand."
         }
       ],
       "subtypes": [
@@ -1267,10 +987,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1280,18 +996,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1315,7 +1019,7 @@
       "rulings": [
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
+          "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature’s power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
         },
         {
           "date": "2007-10-01",
@@ -1323,7 +1027,7 @@
         },
         {
           "date": "2007-10-01",
-          "text": "Lignify overwrites previous effects that changed the enchanted creature's creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
+          "text": "Lignify overwrites previous effects that changed the enchanted creature’s creature types. Any such effects that apply after Lignify enters the battlefield will work normally."
         },
         {
           "date": "2007-10-01",
@@ -1331,11 +1035,11 @@
         },
         {
           "date": "2007-10-01",
-          "text": "If a previous effect switched the creature's power and toughness, that effect still applies (though it will apply to the creature's new power and toughness)."
+          "text": "If a previous effect switched the creature’s power and toughness, that effect still applies (though it will apply to the creature’s new power and toughness)."
         },
         {
           "date": "2007-10-01",
-          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it's applied before the creature loses the ability."
+          "text": "If the enchanted creature has a characteristic-defining ability that specifies its color, that ability will still have its effect because it’s applied before the creature loses the ability."
         },
         {
           "date": "2007-10-01",
@@ -1343,11 +1047,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will overwrite any previous effects that set the enchanted creature's power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
+          "text": "Lignify will overwrite any previous effects that set the enchanted creature’s power or toughness (such as Serendib Sorcerer does). Any such effects that apply after Lignify entered the battlefield will work normally."
         },
         {
           "date": "2009-10-01",
-          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature's power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
+          "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature’s power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
         }
       ],
       "subtypes": [
@@ -1380,27 +1084,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1430,7 +1118,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         },
         {
           "date": "2008-08-01",
@@ -1462,27 +1150,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1508,7 +1180,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If cast targeting an opponent's creature, you get the Elephant when that creature goes to the graveyard."
+          "text": "If cast targeting an opponent’s creature, you get the Elephant when that creature goes to the graveyard."
         }
       ],
       "subtypes": [
@@ -1538,27 +1210,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1598,10 +1254,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1610,19 +1262,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1649,7 +1289,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -1677,10 +1317,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1689,19 +1325,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1758,10 +1382,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1771,18 +1391,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1807,11 +1415,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2013-06-07",
-          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won't be affected."
+          "text": "Lands that enter the battlefield or otehrwise come under your control after Rude Awakening resolves won’t be affected."
         }
       ],
       "text": "Choose one —\n• Untap all lands you control.\n• Until end of turn, lands you control become 2/2 creatures that are still lands.\nEntwine {2}{G} (Choose both if you pay the entwine cost.)",
@@ -1838,27 +1446,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1904,10 +1496,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1920,19 +1508,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1966,7 +1542,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
+          "text": "Overrun affects only creatures you control at the time it resolves. It won’t affect creatures that come under your control later in the turn."
         }
       ],
       "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
@@ -1994,7 +1570,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
+          "format": "Khans of Tarkir Block",
           "legality": "Legal"
         },
         {
@@ -2003,30 +1579,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -2069,23 +1621,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2141,27 +1677,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2192,11 +1712,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "text": "Treetop Village enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\n{1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It's still a land. (If it would assign enough damage to its blockers to destroy them, you may have it assign the rest of its damage to defending player or planeswalker.)",
@@ -3175,10 +2695,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3188,18 +2704,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3228,51 +2732,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are permanents. You can cast one at the time you could cast a sorcery. When your planeswalker spell resolves, it enters the battlefield under your control."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are not creatures. Spells and abilities that affect creatures won’t affect them."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers have loyalty. A planeswalker enters the battlefield with a number of loyalty counters on it equal to the number printed in its lower right corner. Activating one of its abilities may cause it to gain or lose loyalty counters. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it. If it has no loyalty counters on it, it’s put into its owner’s graveyard as a state-based action."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers each have a number of activated abilities called “loyalty abilities.” You can activate a loyalty ability of a planeswalker you control only at the time you could cast a sorcery and only if you haven’t activated one of that planeswalker’s loyalty abilities yet that turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "The cost to activate a planeswalker’s loyalty ability is represented by a symbol with a number inside. Up-arrows contain positive numbers, such as “+1”; this means “Put one loyalty counter on this planeswalker.” Down-arrows contain negative numbers, such as “-7”; this means “Remove seven loyalty counters from this planeswalker.” A symbol with a “0” means “Put zero loyalty counters on this planeswalker.”"
-        },
-        {
-          "date": "2013-07-01",
-          "text": "You can’t activate a planeswalker’s ability with a negative loyalty cost unless the planeswalker has at least that many loyalty counters on it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers can’t attack (unless an effect turns the planeswalker into a creature). However, they can be attacked. Each of your attacking creatures can attack your opponent or a planeswalker that player controls. You say which as you declare attackers."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If your planeswalkers are being attacked, you can block the attackers as normal."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a creature that’s attacking a planeswalker isn’t blocked, it’ll deal its combat damage to that planeswalker. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a source you control would deal noncombat damage to an opponent, you may have that source deal that damage to a planeswalker that opponent controls instead. For example, although you can’t target a planeswalker with Shock, you can target your opponent with Shock, and then as Shock resolves, choose to have Shock deal its 2 damage to one of your opponent’s planeswalkers. (You can’t split up that damage between different players and/or planeswalkers.) If you have Shock deal its damage to a planeswalker, two loyalty counters are removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a player controls two or more planeswalkers that share a planeswalker type, that player chooses one of them and the rest are put into their owners’ graveyards as a state-based action."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "subtypes": [
@@ -3303,10 +2763,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3315,19 +2771,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3378,10 +2822,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Kamigawa Block",
           "legality": "Legal"
         },
@@ -3391,18 +2831,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3452,27 +2880,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3528,27 +2940,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3614,10 +3010,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -3627,18 +3019,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3702,10 +3082,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3714,27 +3090,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Shards of Alara Block",
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -3762,7 +3122,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you'll have to sacrifice Fleshbag Marauder."
+          "text": "When the ability resolves, you may sacrifice Fleshbag Marauder itself. If you control no other creatures, you’ll have to sacrifice Fleshbag Marauder."
         },
         {
           "date": "2015-06-22",
@@ -3799,10 +3159,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -3815,19 +3171,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3882,10 +3226,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3894,19 +3234,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3959,27 +3287,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4042,10 +3354,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4055,18 +3363,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4092,7 +3388,7 @@
       "rulings": [
         {
           "date": "2008-05-01",
-          "text": "Faerie Macabre's second ability can be activated only while it's in your hand. You can do this any time you could cast an instant."
+          "text": "Faerie Macabre’s second ability can be activated only while it’s in your hand. You can do this any time you could cast an instant."
         },
         {
           "date": "2008-05-01",
@@ -4129,27 +3425,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4201,10 +3481,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4213,19 +3489,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4275,10 +3539,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4291,19 +3551,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4332,7 +3580,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -4376,10 +3624,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4388,19 +3632,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4426,7 +3658,7 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "You may pay the cost of Skeletal Vampire's activated abilities by sacrificing any Bat, not just a Bat token it created."
+          "text": "You may pay the cost of Skeletal Vampire’s activated abilities by sacrificing any Bat, not just a Bat token it created."
         }
       ],
       "subtypes": [
@@ -4458,10 +3690,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Kamigawa Block",
           "legality": "Legal"
         },
@@ -4471,18 +3699,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4506,11 +3722,11 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         },
         {
           "date": "2009-10-01",
-          "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+          "text": "Activating the ability that turns it into a creature while it’s already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
         }
       ],
       "subtypes": [
@@ -4540,10 +3756,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4552,19 +3764,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4619,27 +3819,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4693,10 +3877,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4706,18 +3886,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4763,10 +3931,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4775,19 +3939,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4818,7 +3970,7 @@
           "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
         }
       ],
-      "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -4843,27 +3995,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4929,18 +4065,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
@@ -4983,10 +4107,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4995,19 +4115,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5038,7 +4146,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -5066,10 +4174,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5079,18 +4183,6 @@
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5116,7 +4208,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -5144,27 +4236,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5193,19 +4269,19 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Rise from the Grave doesn't overwrite any previous colors or types. Rather, it adds another color and another subtype."
+          "text": "Rise from the Grave doesn’t overwrite any previous colors or types. Rather, it adds another color and another subtype."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is normally colorless, it will simply become black. It won't be both black and colorless."
+          "text": "If the targeted creature is normally colorless, it will simply become black. It won’t be both black and colorless."
         },
         {
           "date": "2009-10-01",
-          "text": "A later effect that changes the affected creature's colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature's types or subtypes."
+          "text": "A later effect that changes the affected creature’s colors will overwrite that part of Rise from the Grave effect; the creature will be just the new color. The same is true about an effect that changes the affected creature’s types or subtypes."
         },
         {
           "date": "2009-10-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
@@ -5233,10 +4309,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5246,18 +4318,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5301,7 +4361,7 @@
         },
         {
           "date": "2010-08-15",
-          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player's life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you'll gain 6 life."
+          "text": "The amount of damage dealt to a creature is not bounded by its toughness, and the amount of damage dealt to a player is not bounded by that player’s life total. For example, if Corrupt deals 6 damage to a 2/2 creature, you’ll gain 6 life."
         },
         {
           "date": "2013-07-01",
@@ -5332,10 +4392,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5344,23 +4400,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Scars of Mirrodin Block",
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5385,11 +4429,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token's owner is the player under whose control it entered the battlefield."
+          "text": "A token’s owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -5415,23 +4459,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6438,20 +5466,6 @@
       "id": "0de29c80e632561e58077cf87c624bb1d65eb07b",
       "imageName": "beast1",
       "layout": "token",
-      "legalities": [
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        }
-      ],
       "multiverseid": 201842,
       "name": "Beast",
       "number": "T1",
@@ -6478,20 +5492,6 @@
       "id": "8c8a310816340dd6b923f84e2c5e5edfd8d3f9ca",
       "imageName": "beast2",
       "layout": "token",
-      "legalities": [
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        }
-      ],
       "multiverseid": 201844,
       "name": "Beast",
       "number": "T2",
@@ -6518,20 +5518,6 @@
       "id": "3302ed869163a047a516800c42a29d1dff9b7a14",
       "imageName": "elephant",
       "layout": "token",
-      "legalities": [
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        }
-      ],
       "multiverseid": 201843,
       "name": "Elephant",
       "number": "T3",

--- a/json/FUT.json
+++ b/json/FUT.json
@@ -68,6 +68,18 @@
       "timeshifted common"
     ]
   ],
+  "translations": {
+    "de": "Blick in die Zukunft",
+    "fr": "Vision de l'Avenir",
+    "it": "Visione Futura",
+    "es": "Visión del Futuro",
+    "pt": "Visão do Futuro",
+    "jp": "未来予知",
+    "cn": "预知将来",
+    "ru": "Взгляд в Будущее"
+  },
+  "mkm_name": "Future Sight",
+  "mkm_id": 70,
   "cards": [
     {
       "artist": "D. Alexander Gregory",
@@ -129,10 +141,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -141,19 +149,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -162,6 +158,7 @@
         }
       ],
       "manaCost": "{6}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 130345,
       "name": "Angel of Salvation",
       "number": "1",
@@ -278,10 +275,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -290,19 +283,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -311,6 +292,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "2",
       "multiverseid": 132212,
       "name": "Augur il-Vec",
       "number": "2",
@@ -393,10 +375,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -405,19 +383,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -426,6 +392,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 136048,
       "name": "Barren Glory",
       "number": "3",
@@ -438,7 +405,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Both conditions need to be true for Barren Glory's ability to trigger, and they both need to be true when the ability resolves or it will do nothing. In between, you can control permanents and/or have cards in hand."
+          "text": "Both conditions need to be true for Barren Glory’s ability to trigger, and they both need to be true when the ability resolves or it will do nothing. In between, you can control permanents and/or have cards in hand."
         }
       ],
       "text": "At the beginning of your upkeep, if you control no permanents other than Barren Glory and have no cards in hand, you win the game.",
@@ -507,10 +474,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -519,19 +482,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -540,6 +491,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "4",
       "multiverseid": 126204,
       "name": "Chronomantic Escape",
       "number": "4",
@@ -552,43 +504,43 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "Chronomantic Escape can affect creatures that aren't on the battlefield at the time it resolves, because it modifies the announcement of an attack, not the creatures on the battlefield. For example, if Chronomantic Escape resolves on your turn, then on your opponent's turn he or she casts a creature with haste, that creature can't attack that turn."
+          "text": "Chronomantic Escape can affect creatures that aren’t on the battlefield at the time it resolves, because it modifies the announcement of an attack, not the creatures on the battlefield. For example, if Chronomantic Escape resolves on your turn, then on your opponent’s turn he or she casts a creature with haste, that creature can’t attack that turn."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -596,7 +548,7 @@
         },
         {
           "date": "2014-02-01",
-          "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
+          "text": "Unless some effect explicitly says otherwise, a creature that can’t attack you can still attack a planeswalker you control."
         }
       ],
       "text": "Until your next turn, creatures can't attack you. Exile Chronomantic Escape with three time counters on it.\nSuspend 3—{2}{W} (Rather than cast this card from your hand, you may pay {2}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
@@ -665,10 +617,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -677,19 +625,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -698,6 +634,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "5",
       "multiverseid": 136207,
       "name": "Dust of Moments",
       "number": "5",
@@ -774,10 +711,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -786,19 +719,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -807,6 +728,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "6",
       "multiverseid": 136192,
       "name": "Even the Odds",
       "number": "6",
@@ -819,7 +741,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn't matter how many creatures you control as Even the Odds resolves."
+          "text": "It doesn’t matter how many creatures you control as Even the Odds resolves."
         }
       ],
       "text": "Cast Even the Odds only if you control fewer creatures than each opponent.\nPut three 1/1 white Soldier creature tokens onto the battlefield.",
@@ -889,10 +811,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -901,19 +819,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -922,6 +828,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "7",
       "multiverseid": 136200,
       "name": "Gift of Granite",
       "number": "7",
@@ -1000,10 +907,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1012,19 +915,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1033,6 +924,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "8",
       "multiverseid": 130680,
       "name": "Intervention Pact",
       "number": "8",
@@ -1049,7 +941,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.\nAt the beginning of your next upkeep, pay {1}{W}{W}. If you don't, you lose the game.",
@@ -1118,10 +1010,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1130,19 +1018,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1151,6 +1027,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "9",
       "multiverseid": 126164,
       "name": "Judge Unworthy",
       "number": "9",
@@ -1226,10 +1103,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1238,19 +1111,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1259,6 +1120,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "10",
       "multiverseid": 130698,
       "name": "Knight of Sursi",
       "number": "10",
@@ -1272,39 +1134,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1382,10 +1244,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1394,19 +1252,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1415,6 +1261,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 126146,
       "name": "Lost Auramancers",
       "number": "11",
@@ -1428,14 +1275,14 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Lost Auramancers doesn't have to have been sacrificed as part of the vanishing ability for its last ability to trigger. It will trigger no matter why it was put into a graveyard from the battlefield, as long as it had no time counters on it at the time."
+          "text": "Lost Auramancers doesn’t have to have been sacrificed as part of the vanishing ability for its last ability to trigger. It will trigger no matter why it was put into a graveyard from the battlefield, as long as it had no time counters on it at the time."
         }
       ],
       "subtypes": [
         "Human",
         "Wizard"
       ],
-      "text": "Vanishing 3 (This permanent enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Lost Auramancers dies, if it had no time counters on it, you may search your library for an enchantment card and put it onto the battlefield. If you do, shuffle your library.",
+      "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Lost Auramancers dies, if it had no time counters on it, you may search your library for an enchantment card and put it onto the battlefield. If you do, shuffle your library.",
       "toughness": "3",
       "type": "Creature — Human Wizard",
       "types": [
@@ -1503,10 +1350,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1515,19 +1358,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1536,6 +1367,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "12",
       "multiverseid": 136148,
       "name": "Magus of the Moat",
       "number": "12",
@@ -1617,10 +1449,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1629,19 +1457,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1650,6 +1466,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "13",
       "multiverseid": 130689,
       "name": "Marshaling Cry",
       "number": "13",
@@ -1731,10 +1548,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1743,19 +1556,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1764,6 +1565,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "14",
       "multiverseid": 130320,
       "name": "Saltskitter",
       "number": "14",
@@ -1777,7 +1579,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If a creature enters the battlefield after \"at the beginning of the end step\" abilities have triggered during that turn, Saltskitter won't return to the battlefield until the end of the following turn."
+          "text": "If a creature enters the battlefield after “at the beginning of the end step” abilities have triggered during that turn, Saltskitter won’t return to the battlefield until the end of the following turn."
         }
       ],
       "subtypes": [
@@ -1851,10 +1653,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1863,19 +1661,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1884,6 +1670,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "15",
       "multiverseid": 130327,
       "name": "Samite Censer-Bearer",
       "number": "15",
@@ -1973,10 +1760,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1985,19 +1768,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2006,6 +1777,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "16",
       "multiverseid": 126200,
       "name": "Scout's Warning",
       "number": "16",
@@ -2018,35 +1790,35 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Scout's Warning works just like Quicken, except for creatures instead of sorceries."
+          "text": "Scout’s Warning works just like Quicken, except for creatures instead of sorceries."
         },
         {
           "date": "2007-05-01",
-          "text": "During the turn you cast Scout's Warning, you can suspend creature cards from your hand at the time you could cast an instant. This ends as soon as you actually cast a creature card."
+          "text": "During the turn you cast Scout’s Warning, you can suspend creature cards from your hand at the time you could cast an instant. This ends as soon as you actually cast a creature card."
         },
         {
           "date": "2007-05-01",
-          "text": "Scout's Warning affects only the next creature card cast that turn, even if that creature already had flash."
+          "text": "Scout’s Warning affects only the next creature card cast that turn, even if that creature already had flash."
         },
         {
           "date": "2007-05-01",
-          "text": "Scout's Warning allows you to cast a noncreature card with morph (such as Lumithread Field) face down as though it had flash. It won't affect that card if you cast it face up."
+          "text": "Scout’s Warning allows you to cast a noncreature card with morph (such as Lumithread Field) face down as though it had flash. It won’t affect that card if you cast it face up."
         },
         {
           "date": "2013-04-15",
-          "text": "You don't choose a creature card when Scout's Warning resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a creature card, even if you cast that creature at a time you normally could."
+          "text": "You don’t choose a creature card when Scout’s Warning resolves. Rather, this sets up a rule that is true for you until the turn ends or until you cast a creature card, even if you cast that creature at a time you normally could."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast multiple Scout's Warnings on the same turn, they'll all apply to the very next creature spell you cast."
+          "text": "If you cast multiple Scout’s Warnings on the same turn, they’ll all apply to the very next creature spell you cast."
         },
         {
           "date": "2013-04-15",
-          "text": "After Scout's Warning resolves, you can suspend a creature card in your hand any time you can cast an instant. As soon as you actually cast a creature card, you lose this capability."
+          "text": "After Scout’s Warning resolves, you can suspend a creature card in your hand any time you can cast an instant. As soon as you actually cast a creature card, you lose this capability."
         },
         {
           "date": "2013-04-15",
-          "text": "You cannot use this effect to play Dryad Arbor during an opponent's turn."
+          "text": "You cannot use this effect to play Dryad Arbor during an opponent’s turn."
         }
       ],
       "text": "The next creature card you play this turn can be played as though it had flash.\nDraw a card.",
@@ -2115,10 +1887,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2127,19 +1895,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2148,6 +1904,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "17",
       "multiverseid": 132221,
       "name": "Spirit en-Dal",
       "number": "17",
@@ -2228,10 +1985,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2240,19 +1993,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2261,6 +2002,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "18",
       "multiverseid": 136204,
       "name": "Aven Mindcensor",
       "number": "18",
@@ -2278,7 +2020,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The search works exactly the same as normal except that the player doing the searching sees only the top four cards of that library. The player can't look at the other cards in that library at all. Cards not in the top four cards of the library can't be found in the search, even if they're identifiable in some manner."
+          "text": "The search works exactly the same as normal except that the player doing the searching sees only the top four cards of that library. The player can’t look at the other cards in that library at all. Cards not in the top four cards of the library can’t be found in the search, even if they’re identifiable in some manner."
         },
         {
           "date": "2007-05-01",
@@ -2365,10 +2107,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2377,19 +2115,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2398,6 +2124,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "19",
       "multiverseid": 130676,
       "name": "Blade of the Sixth Pride",
       "number": "19",
@@ -2479,10 +2206,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2491,19 +2214,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2512,6 +2223,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "20",
       "multiverseid": 130334,
       "name": "Bound in Silence",
       "number": "20",
@@ -2525,11 +2237,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you put Bound in Silence onto the battlefield without casting it, perhaps using the \"recruiting\" ability of a card like Amrou Scout, it will enter attached to a creature. You choose that creature as you're putting it onto the battlefield. If there's no creature on the battlefield it can be attached to, it stays in whatever zone it was in."
+          "text": "If you put Bound in Silence onto the battlefield without casting it, perhaps using the “recruiting” ability of a card like Amrou Scout, it will enter attached to a creature. You choose that creature as you’re putting it onto the battlefield. If there’s no creature on the battlefield it can be attached to, it stays in whatever zone it was in."
         },
         {
           "date": "2007-05-01",
-          "text": "Bound in Silence isn't a creature and isn't affected by any effect that affects creatures or Rebel creatures."
+          "text": "Bound in Silence isn’t a creature and isn’t affected by any effect that affects creatures or Rebel creatures."
         }
       ],
       "subtypes": [
@@ -2604,10 +2316,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2616,19 +2324,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2637,6 +2333,7 @@
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "21",
       "multiverseid": 130635,
       "name": "Daybreak Coronet",
       "number": "21",
@@ -2650,11 +2347,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If all other Auras attached to the enchanted creature stop enchanting it, Daybreak Coronet will be attached to an illegal permanent and will be put into its owner's graveyard."
+          "text": "If all other Auras attached to the enchanted creature stop enchanting it, Daybreak Coronet will be attached to an illegal permanent and will be put into its owner’s graveyard."
         },
         {
           "date": "2007-05-01",
-          "text": "Because Retether returns all Auras to the battlefield at the same time, it won't let you attach Daybreak Coronet to a creature unless that creature is already enchanted."
+          "text": "Because Retether returns all Auras to the battlefield at the same time, it won’t let you attach Daybreak Coronet to a creature unless that creature is already enchanted."
         }
       ],
       "subtypes": [
@@ -2727,10 +2424,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2739,19 +2432,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2760,6 +2441,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "22",
       "multiverseid": 130311,
       "name": "Goldmeadow Lookout",
       "number": "22",
@@ -2842,10 +2524,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2854,19 +2532,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2875,6 +2541,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "23",
       "multiverseid": 136201,
       "name": "Imperial Mask",
       "number": "23",
@@ -2891,7 +2558,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Only teammates within the range of influence of Imperial Mask's controller will get a token. Imperial Mask's controller doesn't get a token; that player just gets the Imperial Mask."
+          "text": "Only teammates within the range of influence of Imperial Mask’s controller will get a token. Imperial Mask’s controller doesn’t get a token; that player just gets the Imperial Mask."
         },
         {
           "date": "2007-05-01",
@@ -2974,10 +2641,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2986,19 +2649,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3007,6 +2658,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "24",
       "multiverseid": 130691,
       "name": "Lucent Liminid",
       "number": "24",
@@ -3020,7 +2672,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Lucent Liminid is an enchantment creature, in much the same way that Ornithopter is an artifact creature. It's affected by anything that affects creatures and anything that affects enchantments."
+          "text": "Lucent Liminid is an enchantment creature, in much the same way that Ornithopter is an artifact creature. It’s affected by anything that affects creatures and anything that affects enchantments."
         }
       ],
       "subtypes": [
@@ -3096,10 +2748,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3108,19 +2756,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3129,6 +2765,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "25",
       "multiverseid": 126186,
       "name": "Lumithread Field",
       "number": "25",
@@ -3206,10 +2843,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3218,19 +2851,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3239,6 +2860,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "26",
       "multiverseid": 126165,
       "name": "Lymph Sliver",
       "number": "26",
@@ -3331,10 +2953,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3347,19 +2965,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3368,6 +2974,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "27",
       "multiverseid": 130346,
       "name": "Mistmeadow Skulk",
       "number": "27",
@@ -3382,15 +2989,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "While a spell with X in its cost is on the stack, its converted mana cost takes the chosen value of X into account. Mistmeadow Skulk can be chosen as a target for a Blaze (which has mana cost {X}{R}) if X is 0 or 1, for example, but it can't be chosen as a target for a Blaze if X is 2 or more."
+          "text": "While a spell with X in its cost is on the stack, its converted mana cost takes the chosen value of X into account. Mistmeadow Skulk can be chosen as a target for a Blaze (which has mana cost {X}{R}) if X is 0 or 1, for example, but it can’t be chosen as a target for a Blaze if X is 2 or more."
         },
         {
           "date": "2007-05-01",
-          "text": "A face-down creature has a converted mana cost of 0, so Mistmeadow Skulk doesn't have protection from it ."
+          "text": "A face-down creature has a converted mana cost of 0, so Mistmeadow Skulk doesn’t have protection from it ."
         },
         {
           "date": "2008-05-01",
-          "text": "The protection ability means the following: - Mistmeadow Skulk can't be blocked by creatures with converted mana cost 3 or greater. - Mistmeadow Skulk can't be enchanted by Auras with converted mana cost 3 or greater. It also can't be equipped by Equipment with converted mana cost 3 or greater. - Mistmeadow Skulk can't be targeted by spells with converted mana cost 3 or greater. It also can't be targeted by abilities from sources with converted mana cost 3 or greater. - All damage that would be dealt to Mistmeadow Skulk by sources with converted mana cost 3 or greater is prevented."
+          "text": "The protection ability means the following: - Mistmeadow Skulk can’t be blocked by creatures with converted mana cost 3 or greater. - Mistmeadow Skulk can’t be enchanted by Auras with converted mana cost 3 or greater. It also can’t be equipped by Equipment with converted mana cost 3 or greater. - Mistmeadow Skulk can’t be targeted by spells with converted mana cost 3 or greater. It also can’t be targeted by abilities from sources with converted mana cost 3 or greater. - All damage that would be dealt to Mistmeadow Skulk by sources with converted mana cost 3 or greater is prevented."
         }
       ],
       "subtypes": [
@@ -3465,10 +3072,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3477,19 +3080,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3498,6 +3089,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "28",
       "multiverseid": 136210,
       "name": "Oriss, Samite Guardian",
       "number": "28",
@@ -3584,10 +3176,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3596,19 +3184,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3617,6 +3193,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "29",
       "multiverseid": 136213,
       "name": "Patrician's Scorn",
       "number": "29",
@@ -3694,10 +3271,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3706,19 +3279,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3727,6 +3288,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "30",
       "multiverseid": 136145,
       "name": "Ramosian Revivalist",
       "number": "30",
@@ -3740,7 +3302,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "A \"permanent card\" is an artifact card, a creature card, an enchantment card, a planeswalker card, or a land card. Most \"Rebel permanent cards\" are creature cards."
+          "text": "A “permanent card” is an artifact card, a creature card, an enchantment card, a planeswalker card, or a land card. Most “Rebel permanent cards” are creature cards."
         }
       ],
       "subtypes": [
@@ -3816,10 +3378,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3828,19 +3386,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3849,6 +3395,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "31",
       "multiverseid": 130347,
       "name": "Seht's Tiger",
       "number": "31",
@@ -3931,10 +3478,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3943,19 +3486,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3964,6 +3495,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "32",
       "multiverseid": 132225,
       "name": "Aven Augur",
       "number": "32",
@@ -4045,10 +3577,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4057,19 +3585,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4078,6 +3594,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "33",
       "multiverseid": 130309,
       "name": "Cloudseeder",
       "number": "33",
@@ -4159,10 +3676,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4171,19 +3684,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4192,6 +3693,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "34",
       "multiverseid": 126141,
       "name": "Cryptic Annelid",
       "number": "34",
@@ -4206,7 +3708,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "You do the three different scry actions in sequence, in the order they're printed on the card."
+          "text": "You do the three different scry actions in sequence, in the order they’re printed on the card."
         }
       ],
       "subtypes": [
@@ -4280,10 +3782,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4292,19 +3790,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4313,6 +3799,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "35",
       "multiverseid": 132228,
       "name": "Delay",
       "number": "35",
@@ -4325,11 +3812,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "When the last time counter is removed from the exiled card, it's cast as a completely new spell. Modes and targets are chosen again. If the spell has any additional costs, they must be paid again. If they can't be, the spell can't be cast and stays exiled."
+          "text": "When the last time counter is removed from the exiled card, it’s cast as a completely new spell. Modes and targets are chosen again. If the spell has any additional costs, they must be paid again. If they can’t be, the spell can’t be cast and stays exiled."
         },
         {
           "date": "2007-05-01",
-          "text": "If the spell targeted by Delay was cast with flashback, Delay's effect will exile it, not the flashback effect. The card will get time counters and gain suspend (if it didn't already have suspend)."
+          "text": "If the spell targeted by Delay was cast with flashback, Delay’s effect will exile it, not the flashback effect. The card will get time counters and gain suspend (if it didn’t already have suspend)."
         }
       ],
       "text": "Counter target spell. If the spell is countered this way, exile it with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend. (At the beginning of its owner's upkeep, remove a time counter from that card. When the last is removed, the player plays it without paying its mana cost. If it's a creature, it has haste.)",
@@ -4399,10 +3886,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4411,19 +3894,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4432,6 +3903,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "36",
       "multiverseid": 130669,
       "name": "Foresee",
       "number": "36",
@@ -4508,10 +3980,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4520,19 +3988,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4541,6 +3997,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "37",
       "multiverseid": 130694,
       "name": "Infiltrator il-Kor",
       "number": "37",
@@ -4554,39 +4011,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4664,10 +4121,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4676,19 +4129,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4697,6 +4138,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "38",
       "multiverseid": 126139,
       "name": "Leaden Fists",
       "number": "38",
@@ -4775,10 +4217,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4787,19 +4225,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4808,6 +4234,7 @@
         }
       ],
       "manaCost": "{7}{U}",
+      "mciNumber": "39",
       "multiverseid": 136195,
       "name": "Maelstrom Djinn",
       "number": "39",
@@ -4821,7 +4248,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Maelstrom Djinn turns face up and then is somehow turned face down, it will still have vanishing and time counters. The vanishing ability will continue to work as normal. If it's turned face up again, it will get more time counters on it, but it will also get another copy of vanishing. Both abilities would trigger during its controller's upkeep."
+          "text": "If Maelstrom Djinn turns face up and then is somehow turned face down, it will still have vanishing and time counters. The vanishing ability will continue to work as normal. If it’s turned face up again, it will get more time counters on it, but it will also get another copy of vanishing. Both abilities would trigger during its controller’s upkeep."
         }
       ],
       "subtypes": [
@@ -4895,10 +4322,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4907,19 +4330,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4928,6 +4339,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}{U}",
+      "mciNumber": "40",
       "multiverseid": 136051,
       "name": "Magus of the Future",
       "number": "40",
@@ -4941,7 +4353,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2007-05-01",
@@ -4957,7 +4369,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
         }
       ],
       "subtypes": [
@@ -5031,10 +4443,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5043,19 +4451,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5064,6 +4460,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "41",
       "multiverseid": 126156,
       "name": "Mystic Speculation",
       "number": "41",
@@ -5140,10 +4537,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5152,19 +4545,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5173,6 +4554,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "42",
       "multiverseid": 130701,
       "name": "Pact of Negation",
       "number": "42",
@@ -5186,7 +4568,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Counter target spell.\nAt the beginning of your next upkeep, pay {3}{U}{U}. If you don't, you lose the game.",
@@ -5255,10 +4637,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5267,19 +4645,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5288,6 +4654,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "43",
       "multiverseid": 126153,
       "name": "Reality Strobe",
       "number": "43",
@@ -5300,39 +4667,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -5405,10 +4772,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5417,19 +4780,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5438,6 +4789,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "44",
       "multiverseid": 136199,
       "name": "Take Possession",
       "number": "44",
@@ -5455,23 +4807,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -5543,10 +4895,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5555,19 +4903,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5576,6 +4912,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "45",
       "multiverseid": 130342,
       "name": "Unblinking Bleb",
       "number": "45",
@@ -5657,10 +4994,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5669,19 +5002,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5690,6 +5011,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "46",
       "multiverseid": 136209,
       "name": "Venser, Shaper Savant",
       "number": "46",
@@ -5704,15 +5026,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If a spell is returned to its owner's hand, it's removed from the stack and thus will not resolve. The spell isn't countered; it just no longer exists."
+          "text": "If a spell is returned to its owner’s hand, it’s removed from the stack and thus will not resolve. The spell isn’t countered; it just no longer exists."
         },
         {
           "date": "2007-05-01",
-          "text": "If a copy of a spell is returned to its owner's hand, it's moved there, then it will cease to exist as a state-based action."
+          "text": "If a copy of a spell is returned to its owner’s hand, it’s moved there, then it will cease to exist as a state-based action."
         },
         {
           "date": "2007-05-01",
-          "text": "If Venser's enters-the-battlefield ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner's hand."
+          "text": "If Venser’s enters-the-battlefield ability targets a spell cast with flashback, that spell will be exiled instead of returning to its owner’s hand."
         }
       ],
       "subtypes": [
@@ -5790,10 +5112,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5802,19 +5120,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5823,6 +5129,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "47",
       "multiverseid": 136197,
       "name": "Venser's Diffusion",
       "number": "47",
@@ -5899,10 +5206,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5911,19 +5214,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5932,6 +5223,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "48",
       "multiverseid": 136055,
       "name": "Arcanum Wings",
       "number": "48",
@@ -5948,7 +5240,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If on resolution, half the exchange can't be completed (such as if the only Aura in your hand can't enchant the permanent), nothing happens."
+          "text": "If on resolution, half the exchange can’t be completed (such as if the only Aura in your hand can’t enchant the permanent), nothing happens."
         }
       ],
       "subtypes": [
@@ -6021,10 +5313,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6033,19 +5321,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6054,6 +5330,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "49",
       "multiverseid": 126143,
       "name": "Blind Phantasm",
       "number": "49",
@@ -6134,10 +5411,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6146,19 +5419,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6167,6 +5428,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "50",
       "multiverseid": 132229,
       "name": "Bonded Fetch",
       "number": "50",
@@ -6248,10 +5510,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6260,19 +5518,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6281,6 +5527,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "51",
       "multiverseid": 136198,
       "name": "Linessa, Zephyr Mage",
       "number": "51",
@@ -6294,7 +5541,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Linessa's grandeur ability targets only a player. That player chooses which permanents to return as the ability resolves. The permanents are returned one at a time, in a specific sequence. The player can't return an artifact creature and have that count as both the artifact and the creature, for example."
+          "text": "Linessa’s grandeur ability targets only a player. That player chooses which permanents to return as the ability resolves. The permanents are returned one at a time, in a specific sequence. The player can’t return an artifact creature and have that count as both the artifact and the creature, for example."
         }
       ],
       "subtypes": [
@@ -6372,10 +5619,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6384,19 +5627,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6405,6 +5636,7 @@
         }
       ],
       "manaCost": "{X}{U}{U}",
+      "mciNumber": "52",
       "multiverseid": 126151,
       "name": "Logic Knot",
       "number": "52",
@@ -6418,7 +5650,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Using delve doesn't reduce the value of X. It just reduces the amount of mana Logic Knot's controller has to pay."
+          "text": "Using delve doesn’t reduce the value of X. It just reduces the amount of mana Logic Knot’s controller has to pay."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nCounter target spell unless its controller pays {X}.",
@@ -6488,10 +5720,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6500,19 +5728,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6521,6 +5737,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "53",
       "multiverseid": 136202,
       "name": "Mesmeric Sliver",
       "number": "53",
@@ -6617,10 +5834,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6629,19 +5842,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6650,6 +5851,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "54",
       "multiverseid": 136140,
       "name": "Narcomoeba",
       "number": "54",
@@ -6664,11 +5866,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Narcomoeba is revealed or looked at while moving from your library to your graveyard (such as with Mind Funeral), its ability will trigger when it's put into your graveyard. It was still in your library while it was revealed or being looked at."
+          "text": "If Narcomoeba is revealed or looked at while moving from your library to your graveyard (such as with Mind Funeral), its ability will trigger when it’s put into your graveyard. It was still in your library while it was revealed or being looked at."
         },
         {
           "date": "2007-05-01",
-          "text": "If Narcomoeba is removed from your graveyard before its ability resolves, it won't be put onto the battlefield."
+          "text": "If Narcomoeba is removed from your graveyard before its ability resolves, it won’t be put onto the battlefield."
         }
       ],
       "subtypes": [
@@ -6743,10 +5945,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6755,19 +5953,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6776,6 +5962,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "55",
       "multiverseid": 130564,
       "name": "Nix",
       "number": "55",
@@ -6792,11 +5979,11 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Nix doesn't check whether a spell's mana cost is 0. Rather, it checks how much mana was actually spent to cast it. It can counter a spell with mana cost 0 (such as Slaughter Pact), a spell cast via an alternative nonmana cost (such as Allosaurus Rider) or alternative cost of {0} (such as Basking Rootwalla), a spell whose cost to cast it was reduced to 0 (such as Frogmite), a spell cast without paying its cost due to an effect (such as suspend or Mindleech Mass's ability), or a copy of a spell, among other possibilities. It will not counter a spell that had an additional or alternative mana cost paid to cast it, regardless of that spell's converted mana cost (such as a face-down spell cast with morph, or an Ornithopter cast while Trinisphere is on the battlefield, for example)."
+          "text": "Nix doesn’t check whether a spell’s mana cost is 0. Rather, it checks how much mana was actually spent to cast it. It can counter a spell with mana cost 0 (such as Slaughter Pact), a spell cast via an alternative nonmana cost (such as Allosaurus Rider) or alternative cost of {0} (such as Basking Rootwalla), a spell whose cost to cast it was reduced to 0 (such as Frogmite), a spell cast without paying its cost due to an effect (such as suspend or Mindleech Mass’s ability), or a copy of a spell, among other possibilities. It will not counter a spell that had an additional or alternative mana cost paid to cast it, regardless of that spell’s converted mana cost (such as a face-down spell cast with morph, or an Ornithopter cast while Trinisphere is on the battlefield, for example)."
         },
         {
           "date": "2007-05-01",
-          "text": "Nix checks whether any player paid mana to cast the spell, not whether its current controller did. If Commandeer is cast on a spell, then Nix is cast on that spell, Nix won't counter it unless the player who originally cast that spell spent no mana to cast it."
+          "text": "Nix checks whether any player paid mana to cast the spell, not whether its current controller did. If Commandeer is cast on a spell, then Nix is cast on that spell, Nix won’t counter it unless the player who originally cast that spell spent no mana to cast it."
         }
       ],
       "text": "Counter target spell if no mana was spent to cast it.",
@@ -6867,10 +6054,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6879,19 +6062,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6900,6 +6071,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "56",
       "multiverseid": 136212,
       "name": "Sarcomite Myr",
       "number": "56",
@@ -6990,10 +6162,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7002,19 +6170,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7023,6 +6179,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "57",
       "multiverseid": 136158,
       "name": "Second Wind",
       "number": "57",
@@ -7035,7 +6192,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "These abilities are abilities of the Aura, not abilities granted to the creature. Only the Aura's controller can activate them."
+          "text": "These abilities are abilities of the Aura, not abilities granted to the creature. Only the Aura’s controller can activate them."
         }
       ],
       "subtypes": [
@@ -7108,10 +6265,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7120,19 +6273,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7141,6 +6282,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "58",
       "multiverseid": 136214,
       "name": "Shapeshifter's Marrow",
       "number": "58",
@@ -7153,15 +6295,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If the revealed card isn't a creature card, it stays on top of that player's library. Shapeshifter's Marrow remains an enchantment."
+          "text": "If the revealed card isn’t a creature card, it stays on top of that player’s library. Shapeshifter’s Marrow remains an enchantment."
         },
         {
           "date": "2007-05-01",
-          "text": "If the revealed card is a creature card, Shapeshifter's Marrow becomes a copy of that card permanently. It's no longer an enchantment."
+          "text": "If the revealed card is a creature card, Shapeshifter’s Marrow becomes a copy of that card permanently. It’s no longer an enchantment."
         },
         {
           "date": "2007-05-01",
-          "text": "In a Two-Headed Giant game, this ability triggers separately for each player at the start of the opposing team's turn. If the first ability to resolve reveals a creature card, Shapeshifter's Marrow becomes a creature. If the second ability to resolve also reveals a creature card, the ex-Shapeshifter's Marrow then becomes a copy of that creature."
+          "text": "In a Two-Headed Giant game, this ability triggers separately for each player at the start of the opposing team’s turn. If the first ability to resolve reveals a creature card, Shapeshifter’s Marrow becomes a creature. If the second ability to resolve also reveals a creature card, the ex-Shapeshifter’s Marrow then becomes a copy of that creature."
         }
       ],
       "text": "At the beginning of each opponent's upkeep, that player reveals the top card of his or her library. If it's a creature card, the player puts the card into his or her graveyard and Shapeshifter's Marrow becomes a copy of that card. (If it does, it loses this ability.)",
@@ -7231,10 +6373,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7243,19 +6381,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7264,6 +6390,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "59",
       "multiverseid": 136032,
       "name": "Spellweaver Volute",
       "number": "59",
@@ -7276,27 +6403,27 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This Aura targets, and enchants, an instant card in a graveyard. This is the first Aura that enchants something that's neither a permanent nor a player."
+          "text": "This Aura targets, and enchants, an instant card in a graveyard. This is the first Aura that enchants something that’s neither a permanent nor a player."
         },
         {
           "date": "2007-05-01",
-          "text": "The Aura will be on the battlefield attached to a card in a different zone. The Aura won't be in the graveyard. The enchanted card won't be on the battlefield."
+          "text": "The Aura will be on the battlefield attached to a card in a different zone. The Aura won’t be in the graveyard. The enchanted card won’t be on the battlefield."
         },
         {
           "date": "2007-05-01",
-          "text": "If the enchanted card changes zones (due to being cast with flashback, or being exiled with Cremate, for example), Spellweaver Volute \"falls off\" and is put into its owner's graveyard as a state-based action."
+          "text": "If the enchanted card changes zones (due to being cast with flashback, or being exiled with Cremate, for example), Spellweaver Volute “falls off” and is put into its owner’s graveyard as a state-based action."
         },
         {
           "date": "2007-05-01",
-          "text": "When you cast a sorcery spell, Spellweaver Volute's ability triggers. It will make a copy of the enchanted card. The copy will exist in the graveyard. You'll have the option to cast the copy. If you don't, the copy remains in the graveyard and ceases to exist the next time state-based actions are checked. If you do cast the copy, the copy is cast from the graveyard. After you finish casting it, the enchanted card is exiled and you must choose a new instant card in a graveyard to attach Spellweaver Volute to. If you can't, Spellweaver Volute remains on the battlefield attached to nothing and is then put into the graveyard the next time state-based actions are checked."
+          "text": "When you cast a sorcery spell, Spellweaver Volute’s ability triggers. It will make a copy of the enchanted card. The copy will exist in the graveyard. You’ll have the option to cast the copy. If you don’t, the copy remains in the graveyard and ceases to exist the next time state-based actions are checked. If you do cast the copy, the copy is cast from the graveyard. After you finish casting it, the enchanted card is exiled and you must choose a new instant card in a graveyard to attach Spellweaver Volute to. If you can’t, Spellweaver Volute remains on the battlefield attached to nothing and is then put into the graveyard the next time state-based actions are checked."
         },
         {
           "date": "2007-05-01",
-          "text": "Say Spellweaver Volute's ability triggers, then the enchanted instant card is exiled in response. Spellweaver Volute, which is now enchanting nothing, is put into its owner's graveyard as a state-based action. When the Volute's ability resolves, it will check its last existence on the battlefield and identify the \"enchanted card\" as \"nothing,\" so no copy is created."
+          "text": "Say Spellweaver Volute’s ability triggers, then the enchanted instant card is exiled in response. Spellweaver Volute, which is now enchanting nothing, is put into its owner’s graveyard as a state-based action. When the Volute’s ability resolves, it will check its last existence on the battlefield and identify the “enchanted card” as “nothing,” so no copy is created."
         },
         {
           "date": "2007-05-01",
-          "text": "Say Spellweaver Volute's ability triggers, then Spellweaver Volute leaves the battlefield in response. Then the instant card that was enchanted is removed from the graveyard in response. When the Volute's ability resolves, it will check its last existence on the battlefield and identify the \"enchanted card\" as that instant card, so the card is copied and controller of the triggered ability may cast it."
+          "text": "Say Spellweaver Volute’s ability triggers, then Spellweaver Volute leaves the battlefield in response. Then the instant card that was enchanted is removed from the graveyard in response. When the Volute’s ability resolves, it will check its last existence on the battlefield and identify the “enchanted card” as that instant card, so the card is copied and controller of the triggered ability may cast it."
         }
       ],
       "subtypes": [
@@ -7369,10 +6496,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7381,19 +6504,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7402,6 +6513,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "60",
       "multiverseid": 130344,
       "name": "Spin into Myth",
       "number": "60",
@@ -7415,7 +6527,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The opponent chosen for the fateseal action doesn't have to be the player who controlled the target creature."
+          "text": "The opponent chosen for the fateseal action doesn’t have to be the player who controlled the target creature."
         }
       ],
       "text": "Put target creature on top of its owner's library, then fateseal 2. (To fateseal 2, look at the top two cards of an opponent's library, then put any number of them on the bottom of that player's library and the rest on top in any order.)",
@@ -7485,10 +6597,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7497,19 +6605,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7518,6 +6614,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "61",
       "multiverseid": 130325,
       "name": "Vedalken Æthermage",
       "number": "61",
@@ -7531,7 +6628,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Wizardcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Wizard card. After you find a Wizard card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Wizardcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Wizard card. After you find a Wizard card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -7543,7 +6640,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You can choose to find any card with the Wizard creature type, even if it isn't a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Wizard card in your library."
+          "text": "You can choose to find any card with the Wizard creature type, even if it isn’t a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Wizard card in your library."
         }
       ],
       "subtypes": [
@@ -7620,10 +6717,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7632,19 +6725,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7653,6 +6734,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "62",
       "multiverseid": 126178,
       "name": "Whip-Spine Drake",
       "number": "62",
@@ -7735,10 +6817,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7747,19 +6825,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7768,6 +6834,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "63",
       "multiverseid": 132224,
       "name": "Augur of Skulls",
       "number": "63",
@@ -7850,10 +6917,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7862,19 +6925,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7883,6 +6934,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "64",
       "multiverseid": 126177,
       "name": "Cutthroat il-Dal",
       "number": "64",
@@ -7964,10 +7016,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7976,19 +7024,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7997,6 +7033,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "65",
       "multiverseid": 126131,
       "name": "Festering March",
       "number": "65",
@@ -8009,39 +7046,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8114,10 +7151,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8126,19 +7159,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8147,6 +7168,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "66",
       "multiverseid": 130690,
       "name": "Gibbering Descent",
       "number": "66",
@@ -8162,7 +7184,7 @@
           "text": "If you have no cards in hand at the time your upkeep step would start, instead that step is skipped and your draw step starts."
         }
       ],
-      "text": "At the beginning of each player's upkeep, that player loses 1 life and discards a card.\nHellbent — Skip your upkeep step if you have no cards in hand.\nMadness {2}{B}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "At the beginning of each player's upkeep, that player loses 1 life and discards a card.\nHellbent — Skip your upkeep step if you have no cards in hand.\nMadness {2}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Enchantment",
       "types": [
         "Enchantment"
@@ -8229,10 +7251,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8241,19 +7259,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8262,6 +7268,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "67",
       "multiverseid": 126159,
       "name": "Grave Peril",
       "number": "67",
@@ -8279,7 +7286,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If multiple nonblack creatures enter the battlefield at the same time, Grave Peril will destroy only one of them. Grave Peril's ability will trigger multiple times, but only the first one to resolve will do anything."
+          "text": "If multiple nonblack creatures enter the battlefield at the same time, Grave Peril will destroy only one of them. Grave Peril’s ability will trigger multiple times, but only the first one to resolve will do anything."
         },
         {
           "date": "2007-05-01",
@@ -8352,10 +7359,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8364,19 +7367,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8385,6 +7376,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "68",
       "multiverseid": 130683,
       "name": "Ichor Slick",
       "number": "68",
@@ -8406,7 +7398,7 @@
           "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
         }
       ],
-      "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Target creature gets -3/-3 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)\nMadness {3}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -8473,10 +7465,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8485,19 +7473,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8506,6 +7482,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "69",
       "multiverseid": 130332,
       "name": "Lost Hours",
       "number": "69",
@@ -8592,10 +7569,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8604,19 +7577,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8625,6 +7586,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "70",
       "multiverseid": 136033,
       "name": "Magus of the Abyss",
       "number": "70",
@@ -8713,10 +7675,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8725,19 +7683,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8746,6 +7692,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "71",
       "multiverseid": 130316,
       "name": "Minions' Murmurs",
       "number": "71",
@@ -8821,10 +7768,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8833,19 +7776,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8854,6 +7785,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "72",
       "multiverseid": 136206,
       "name": "Nihilith",
       "number": "72",
@@ -8867,43 +7799,43 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If a token is put into an opponent's graveyard from the battlefield, or a copy of a spell is put into an opponent's graveyard from the stack, Nihilith's ability will not trigger, because the ability references “a card.”"
+          "text": "If a token is put into an opponent’s graveyard from the battlefield, or a copy of a spell is put into an opponent’s graveyard from the stack, Nihilith’s ability will not trigger, because the ability references “a card.”"
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -8980,10 +7912,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8992,19 +7920,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9013,6 +7929,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "73",
       "multiverseid": 132219,
       "name": "Oblivion Crown",
       "number": "73",
@@ -9092,10 +8009,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9104,19 +8017,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9125,6 +8026,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "74",
       "multiverseid": 136211,
       "name": "Pooling Venom",
       "number": "74",
@@ -9137,11 +8039,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The triggered ability triggers whenever the enchanted land becomes tapped, not just when it's tapped for mana."
+          "text": "The triggered ability triggers whenever the enchanted land becomes tapped, not just when it’s tapped for mana."
         },
         {
           "date": "2007-05-01",
-          "text": "Only Pooling Venom's controller can activate the activated ability."
+          "text": "Only Pooling Venom’s controller can activate the activated ability."
         }
       ],
       "subtypes": [
@@ -9213,10 +8115,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9225,19 +8123,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9246,6 +8132,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "75",
       "multiverseid": 126148,
       "name": "Putrid Cyclops",
       "number": "75",
@@ -9333,10 +8220,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9345,19 +8228,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9366,6 +8237,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "76",
       "multiverseid": 126134,
       "name": "Shimian Specter",
       "number": "76",
@@ -9380,11 +8252,11 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The cards you're searching for must be found and exiled if they're in the graveyard because it's a public zone. Finding those cards in the hand and library is optional, because those zones are hidden (even if the hand is temporarily revealed)."
+          "text": "The cards you’re searching for must be found and exiled if they’re in the graveyard because it’s a public zone. Finding those cards in the hand and library is optional, because those zones are hidden (even if the hand is temporarily revealed)."
         },
         {
           "date": "2012-07-01",
-          "text": "If the player has no nonland cards in his or her hand, you can still search that player's library and have him or her shuffle it."
+          "text": "If the player has no nonland cards in his or her hand, you can still search that player’s library and have him or her shuffle it."
         }
       ],
       "subtypes": [
@@ -9457,10 +8329,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9469,19 +8337,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9490,6 +8346,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "77",
       "multiverseid": 130314,
       "name": "Skirk Ridge Exhumer",
       "number": "77",
@@ -9572,10 +8429,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9584,19 +8437,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9605,6 +8446,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "78",
       "multiverseid": 130704,
       "name": "Slaughter Pact",
       "number": "78",
@@ -9618,7 +8460,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Destroy target nonblack creature.\nAt the beginning of your next upkeep, pay {2}{B}. If you don't, you lose the game.",
@@ -9688,10 +8530,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9700,19 +8538,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9721,6 +8547,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "79",
       "multiverseid": 136056,
       "name": "Stronghold Rats",
       "number": "79",
@@ -9734,7 +8561,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "First the active player chooses a card to discard, then each other player in turn order chooses, then all cards are discarded simultaneously. Although the chosen cards will be indicated (so a player can't change his or her mind later), they'll remain face down until they're discarded. You won't know what your opponent is going to discard when making your choice."
+          "text": "First the active player chooses a card to discard, then each other player in turn order chooses, then all cards are discarded simultaneously. Although the chosen cards will be indicated (so a player can’t change his or her mind later), they’ll remain face down until they’re discarded. You won’t know what your opponent is going to discard when making your choice."
         }
       ],
       "subtypes": [
@@ -9807,10 +8634,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9819,19 +8642,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9840,6 +8651,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "80",
       "multiverseid": 136049,
       "name": "Bitter Ordeal",
       "number": "80",
@@ -9916,10 +8728,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9928,19 +8736,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9949,6 +8745,7 @@
         }
       ],
       "manaCost": "{B}{B}{B}",
+      "mciNumber": "81",
       "multiverseid": 136054,
       "name": "Bridge from Below",
       "number": "81",
@@ -9962,7 +8759,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "While Bridge from Below is on the battlefield, it has no effect. It does something only if it's in a graveyard."
+          "text": "While Bridge from Below is on the battlefield, it has no effect. It does something only if it’s in a graveyard."
         },
         {
           "date": "2007-05-01",
@@ -10036,10 +8833,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10048,19 +8841,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10069,6 +8850,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "82",
       "multiverseid": 136043,
       "name": "Death Rattle",
       "number": "82",
@@ -10086,7 +8868,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell's cost."
+          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell’s cost."
         }
       ],
       "text": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nDestroy target nongreen creature. It can't be regenerated.",
@@ -10156,10 +8938,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10168,19 +8946,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10189,6 +8955,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "83",
       "multiverseid": 132226,
       "name": "Deepcavern Imp",
       "number": "83",
@@ -10203,7 +8970,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you have no cards in hand, you can't pay the echo cost and Deepcavern Imp will be sacrificed."
+          "text": "If you have no cards in hand, you can’t pay the echo cost and Deepcavern Imp will be sacrificed."
         }
       ],
       "subtypes": [
@@ -10278,10 +9045,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10290,19 +9053,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10311,6 +9062,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "84",
       "multiverseid": 132220,
       "name": "Fleshwrither",
       "number": "84",
@@ -10399,10 +9151,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10411,19 +9159,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10432,6 +9168,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "85",
       "multiverseid": 126187,
       "name": "Frenzy Sliver",
       "number": "85",
@@ -10446,7 +9183,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         },
         {
           "date": "2013-07-01",
@@ -10528,10 +9265,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10540,19 +9273,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10561,6 +9282,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "86",
       "multiverseid": 132211,
       "name": "Grave Scrabbler",
       "number": "86",
@@ -10574,21 +9296,21 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The second ability checks if Grave Scrabbler was cast as a result of its madness ability. It doesn't matter if the specific cost wasn't paid (for example, if the cost was reduced due to a effect like Cloud Key)."
+          "text": "The second ability checks if Grave Scrabbler was cast as a result of its madness ability. It doesn’t matter if the specific cost wasn’t paid (for example, if the cost was reduced due to a effect like Cloud Key)."
         },
         {
           "date": "2007-05-01",
-          "text": "When Grave Scrabbler enters the battlefield, its ability triggers only if it was cast with madness. If it triggers, you must choose a target, but you don't decide whether to actually return the card until the ability resolves."
+          "text": "When Grave Scrabbler enters the battlefield, its ability triggers only if it was cast with madness. If it triggers, you must choose a target, but you don’t decide whether to actually return the card until the ability resolves."
         },
         {
           "date": "2007-05-01",
-          "text": "You can return a card in a different player's graveyard to that player's hand."
+          "text": "You can return a card in a different player’s graveyard to that player’s hand."
         }
       ],
       "subtypes": [
         "Zombie"
       ],
-      "text": "Madness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)\nWhen Grave Scrabbler enters the battlefield, if its madness cost was paid, you may return target creature card from a graveyard to its owner's hand.",
+      "text": "Madness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)\nWhen Grave Scrabbler enters the battlefield, if its madness cost was paid, you may return target creature card from a graveyard to its owner's hand.",
       "timeshifted": true,
       "toughness": "2",
       "type": "Creature — Zombie",
@@ -10656,10 +9378,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10668,19 +9386,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10689,6 +9395,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "87",
       "multiverseid": 136208,
       "name": "Korlash, Heir to Blackblade",
       "number": "87",
@@ -10775,10 +9482,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10787,19 +9490,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10808,6 +9499,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "88",
       "multiverseid": 126158,
       "name": "Mass of Ghouls",
       "number": "88",
@@ -10889,10 +9581,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10901,19 +9589,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10922,6 +9598,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "89",
       "multiverseid": 130708,
       "name": "Snake Cult Initiation",
       "number": "89",
@@ -11002,10 +9679,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11014,19 +9687,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11035,6 +9696,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "90",
       "multiverseid": 136205,
       "name": "Street Wraith",
       "number": "90",
@@ -11123,10 +9785,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11135,19 +9793,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11156,6 +9802,7 @@
         }
       ],
       "manaCost": "{6}{B}{B}",
+      "mciNumber": "91",
       "multiverseid": 136041,
       "name": "Tombstalker",
       "number": "91",
@@ -11174,7 +9821,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell's cost."
+          "text": "If you sacrifice permanents or discard cards while casting the spell (for example, activating the mana ability of Blood Pet), those cards can be exiled using delve to reduce the spell’s cost."
         }
       ],
       "subtypes": [
@@ -11249,10 +9896,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11261,19 +9904,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11282,6 +9913,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "92",
       "multiverseid": 132222,
       "name": "Witch's Mist",
       "number": "92",
@@ -11294,11 +9926,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If all damage that would be dealt to a creature is prevented, no damage is actually dealt and that creature can't be targeted by Witch's Mist."
+          "text": "If all damage that would be dealt to a creature is prevented, no damage is actually dealt and that creature can’t be targeted by Witch’s Mist."
         },
         {
           "date": "2007-05-01",
-          "text": "If a creature is lethally damaged and regenerates, all damage is removed from that creature. But since it was actually dealt damage earlier in the turn, it can be targeted by Witch's Mist."
+          "text": "If a creature is lethally damaged and regenerates, all damage is removed from that creature. But since it was actually dealt damage earlier in the turn, it can be targeted by Witch’s Mist."
         }
       ],
       "text": "{2}{B}, {T}: Destroy target creature that was dealt damage this turn.",
@@ -11369,10 +10001,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11381,19 +10009,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11402,6 +10018,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "93",
       "multiverseid": 130702,
       "name": "Yixlid Jailer",
       "number": "93",
@@ -11416,11 +10033,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This removes all abilities on all cards in all graveyards -- both the ones that matter in a graveyard (dredge, Chronosavant's ability, etc.) and those that don't."
+          "text": "This removes all abilities on all cards in all graveyards -- both the ones that matter in a graveyard (dredge, Chronosavant’s ability, etc.) and those that don’t."
         },
         {
           "date": "2007-05-01",
-          "text": "If an ability triggers when the object that has it is put into a graveyard from the battlefield, that ability triggers from the battlefield (such as Deadwood Treefolk or Epochrasite, for example), they won't be affected by Yixlid Jailer."
+          "text": "If an ability triggers when the object that has it is put into a graveyard from the battlefield, that ability triggers from the battlefield (such as Deadwood Treefolk or Epochrasite, for example), they won’t be affected by Yixlid Jailer."
         },
         {
           "date": "2007-05-01",
@@ -11432,15 +10049,15 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Some replacement effects cause a card to be put somewhere else instead of being put into a graveyard (such as Legacy Weapon). These effects mean the card is never actually put into the graveyard, so Yixlid Jailer can't affect it."
+          "text": "Some replacement effects cause a card to be put somewhere else instead of being put into a graveyard (such as Legacy Weapon). These effects mean the card is never actually put into the graveyard, so Yixlid Jailer can’t affect it."
         },
         {
           "date": "2007-05-01",
-          "text": "Some cards have abilities that modify how they're put onto the battlefield. For example, Scarwood Treefolk says \"Scarwood Treefolk is put onto the battlefield tapped\" and Triskelion says \"Triskelion enters the battlefield with three +1/+1 counters on it.\" Although these cards won't have these abilities in the graveyard, they will be applied if the cards are put onto the battlefield from the graveyard (due to Zombify, perhaps). What matters is that these cards will have these abilities on the battlefield."
+          "text": "Some cards have abilities that modify how they’re put onto the battlefield. For example, Scarwood Treefolk says “Scarwood Treefolk is put onto the battlefield tapped” and Triskelion says “Triskelion enters the battlefield with three +1/+1 counters on it.” Although these cards won’t have these abilities in the graveyard, they will be applied if the cards are put onto the battlefield from the graveyard (due to Zombify, perhaps). What matters is that these cards will have these abilities on the battlefield."
         },
         {
           "date": "2007-05-01",
-          "text": "If Mistform Ultimus is in the graveyard, the Ultimus will lose its ability that says \"Mistform Ultimus is every creature type,\" but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus's type-changing ability is applied before Yixlid Jailer's ability removes it."
+          "text": "If Mistform Ultimus is in the graveyard, the Ultimus will lose its ability that says “Mistform Ultimus is every creature type,” but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus’s type-changing ability is applied before Yixlid Jailer’s ability removes it."
         }
       ],
       "subtypes": [
@@ -11515,10 +10132,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11527,19 +10140,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11548,6 +10149,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "94",
       "multiverseid": 126193,
       "name": "Arc Blade",
       "number": "94",
@@ -11560,39 +10162,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -11665,10 +10267,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11677,19 +10275,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11698,6 +10284,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "95",
       "multiverseid": 126161,
       "name": "Bogardan Lancer",
       "number": "95",
@@ -11780,10 +10367,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11792,19 +10375,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11813,6 +10384,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "96",
       "multiverseid": 130582,
       "name": "Char-Rumbler",
       "number": "96",
@@ -11826,7 +10398,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Yes, Char-Rumbler's printed power is -1. While its power is -1 or 0, it simply deals no combat damage."
+          "text": "Yes, Char-Rumbler’s printed power is -1. While its power is -1 or 0, it simply deals no combat damage."
         },
         {
           "date": "2007-05-01",
@@ -11834,7 +10406,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If Char-Rumbler's power changes between the assignment of first-strike combat damage and the assignment of normal combat damage, Char-Rumbler will deal a different amount of damage in each combat damage step."
+          "text": "If Char-Rumbler’s power changes between the assignment of first-strike combat damage and the assignment of normal combat damage, Char-Rumbler will deal a different amount of damage in each combat damage step."
         }
       ],
       "subtypes": [
@@ -11908,10 +10480,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11920,19 +10488,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11941,6 +10497,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "97",
       "multiverseid": 132214,
       "name": "Emberwilde Augur",
       "number": "97",
@@ -12024,10 +10581,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12036,19 +10589,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12057,6 +10598,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "98",
       "multiverseid": 130699,
       "name": "Fatal Attraction",
       "number": "98",
@@ -12135,10 +10677,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12147,19 +10685,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12168,6 +10694,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "99",
       "multiverseid": 130707,
       "name": "Gathan Raiders",
       "number": "99",
@@ -12250,10 +10777,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12262,19 +10785,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12283,6 +10794,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "100",
       "multiverseid": 130328,
       "name": "Haze of Rage",
       "number": "100",
@@ -12295,15 +10807,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -12377,10 +10889,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12389,19 +10897,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12410,6 +10906,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "101",
       "multiverseid": 136152,
       "name": "Magus of the Moon",
       "number": "101",
@@ -12423,11 +10920,11 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "Nonbasic lands that are turned into Mountains are still nonbasic. Magus of the Moon does nothing to change the land's supertype."
+          "text": "Nonbasic lands that are turned into Mountains are still nonbasic. Magus of the Moon does nothing to change the land’s supertype."
         },
         {
           "date": "2008-04-01",
-          "text": "Lands that are turned into Mountains will have \"{T}: Add {R} to your mana pool."
+          "text": "Lands that are turned into Mountains will have “{T}: Add {R} to your mana pool."
         }
       ],
       "subtypes": [
@@ -12501,10 +10998,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12513,19 +11006,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12534,6 +11015,7 @@
         }
       ],
       "manaCost": "{X}{R}{R}",
+      "mciNumber": "102",
       "multiverseid": 136154,
       "name": "Molten Disaster",
       "number": "102",
@@ -12548,7 +11030,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it's on the stack."
+          "text": "If Molten Disaster was kicked, Molten Disaster has split second as long as it’s on the stack."
         },
         {
           "date": "2013-06-07",
@@ -12556,23 +11038,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Kicker {R} (You may pay an additional {R} as you cast this spell.)\nIf Molten Disaster was kicked, it has split second. (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nMolten Disaster deals X damage to each creature without flying and each player.",
@@ -12641,10 +11123,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12653,19 +11131,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12674,6 +11140,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "103",
       "multiverseid": 130638,
       "name": "Pact of the Titan",
       "number": "103",
@@ -12686,7 +11153,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Put a 4/4 red Giant creature token onto the battlefield.\nAt the beginning of your next upkeep, pay {4}{R}. If you don't, you lose the game.",
@@ -12755,10 +11222,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12767,19 +11230,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12788,6 +11239,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "104",
       "multiverseid": 136216,
       "name": "Pyromancer's Swath",
       "number": "104",
@@ -12801,11 +11253,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Pyromancer's Swath doesn't change the source or recipient of the damage."
+          "text": "Pyromancer’s Swath doesn’t change the source or recipient of the damage."
         },
         {
           "date": "2007-05-01",
-          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer's Swath will not apply as that source is no longer dealing damage."
+          "text": "If all damage from a source is prevented (because of Pay No Heed, for example) or if a source would deal 0 damage, the effect of Pyromancer’s Swath will not apply as that source is no longer dealing damage."
         },
         {
           "date": "2007-05-01",
@@ -12878,23 +11330,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -12906,15 +11346,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "105",
       "multiverseid": 126199,
       "name": "Riddle of Lightning",
       "number": "105",
@@ -12992,10 +11429,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13004,19 +11437,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13025,6 +11446,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "106",
       "multiverseid": 130591,
       "name": "Rift Elemental",
       "number": "106",
@@ -13039,11 +11461,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The counter is removed as a cost, so it can't be responded to."
+          "text": "The counter is removed as a cost, so it can’t be responded to."
         },
         {
           "date": "2007-05-01",
-          "text": "If an suspended card's last time counter is removed this way, the suspend triggered ability is put on the stack on top of the Rift Elemental ability. The same is true for the vanishing ability of a permanent that loses its last time counter."
+          "text": "If an suspended card’s last time counter is removed this way, the suspend triggered ability is put on the stack on top of the Rift Elemental ability. The same is true for the vanishing ability of a permanent that loses its last time counter."
         }
       ],
       "subtypes": [
@@ -13117,10 +11539,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13129,19 +11547,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13150,6 +11556,7 @@
         }
       ],
       "manaCost": "{6}{R}{R}",
+      "mciNumber": "107",
       "multiverseid": 136161,
       "name": "Scourge of Kher Ridges",
       "number": "107",
@@ -13236,10 +11643,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13248,19 +11651,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13269,6 +11660,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "108",
       "multiverseid": 126201,
       "name": "Shivan Sand-Mage",
       "number": "108",
@@ -13282,43 +11674,43 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "When Shivan Sand-Mage enters the battlefield, if there are no suspended cards and no permanents with time counters on them, you can't choose the second mode. You'll have to choose the first mode, and will have to choose a permanent as a target (though, in this case, the ability won't do anything when it resolves)."
+          "text": "When Shivan Sand-Mage enters the battlefield, if there are no suspended cards and no permanents with time counters on them, you can’t choose the second mode. You’ll have to choose the first mode, and will have to choose a permanent as a target (though, in this case, the ability won’t do anything when it resolves)."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -13396,10 +11788,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13408,19 +11796,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13429,6 +11805,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "109",
       "multiverseid": 130341,
       "name": "Sparkspitter",
       "number": "109",
@@ -13511,10 +11888,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13523,23 +11896,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Scars of Mirrodin Block",
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13548,6 +11909,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "110",
       "multiverseid": 130686,
       "name": "Bloodshot Trainee",
       "number": "110",
@@ -13563,7 +11925,7 @@
       "rulings": [
         {
           "date": "2011-01-01",
-          "text": "Once Bloodshot Trainee's ability is activated, it will resolve as normal even if Bloodshot Trainee's power is less than 4 by the time the ability resolves."
+          "text": "Once Bloodshot Trainee’s ability is activated, it will resolve as normal even if Bloodshot Trainee’s power is less than 4 by the time the ability resolves."
         }
       ],
       "subtypes": [
@@ -13638,10 +12000,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13654,19 +12012,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13675,6 +12021,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "111",
       "multiverseid": 130672,
       "name": "Boldwyr Intimidator",
       "number": "111",
@@ -13774,10 +12121,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13786,19 +12129,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13807,6 +12138,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "112",
       "multiverseid": 136215,
       "name": "Emblem of the Warmind",
       "number": "112",
@@ -13893,10 +12225,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13905,19 +12233,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13926,6 +12242,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "113",
       "multiverseid": 132227,
       "name": "Flowstone Embrace",
       "number": "113",
@@ -13938,7 +12255,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "This ability is an ability of the Aura, not an ability granted to the creature. Only the Aura's controller can activate it."
+          "text": "This ability is an ability of the Aura, not an ability granted to the creature. Only the Aura’s controller can activate it."
         }
       ],
       "subtypes": [
@@ -14011,10 +12328,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14023,19 +12336,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14044,6 +12345,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "114",
       "multiverseid": 126149,
       "name": "Fomori Nomad",
       "number": "114",
@@ -14122,10 +12424,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14134,19 +12432,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14155,6 +12441,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "115",
       "multiverseid": 136044,
       "name": "Ghostfire",
       "number": "115",
@@ -14239,10 +12526,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14251,19 +12534,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14272,6 +12543,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "116",
       "multiverseid": 136040,
       "name": "Grinning Ignus",
       "number": "116",
@@ -14286,11 +12558,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Although Grinning Ignus's ability has a timing restriction, it's still a mana ability. It doesn't use the stack and it can't be responded to."
+          "text": "Although Grinning Ignus’s ability has a timing restriction, it’s still a mana ability. It doesn’t use the stack and it can’t be responded to."
         },
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "subtypes": [
@@ -14365,10 +12637,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14377,19 +12645,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14398,6 +12654,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "117",
       "multiverseid": 130695,
       "name": "Henchfiend of Ukor",
       "number": "117",
@@ -14479,10 +12736,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14491,19 +12744,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14512,6 +12753,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "118",
       "multiverseid": 126162,
       "name": "Homing Sliver",
       "number": "118",
@@ -14526,7 +12768,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Slivercycling doesn't allow you to draw a card. Instead, it lets you search your library for a Sliver card. After you find a Sliver card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Slivercycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Sliver card. After you find a Sliver card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -14538,7 +12780,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "You can choose to find any card with the Sliver creature type, even if it isn't a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Sliver card in your graveyard."
+          "text": "You can choose to find any card with the Sliver creature type, even if it isn’t a creature card. This includes, for example, Tribal cards with the Changeling ability. You can also choose not to find a card, even if there is a Sliver card in your library."
         },
         {
           "date": "2013-07-01",
@@ -14620,10 +12862,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14632,19 +12870,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14653,6 +12879,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "119",
       "multiverseid": 136137,
       "name": "Shah of Naar Isle",
       "number": "119",
@@ -14670,7 +12897,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If you use Thick-Skinned Goblin's ability to pay {0} instead of Shah of Naar Isle's echo cost, the Shah's last ability will trigger."
+          "text": "If you use Thick-Skinned Goblin’s ability to pay {0} instead of Shah of Naar Isle’s echo cost, the Shah’s last ability will trigger."
         },
         {
           "date": "2007-05-01",
@@ -14748,10 +12975,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14760,19 +12983,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14781,6 +12992,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "120",
       "multiverseid": 136160,
       "name": "Skizzik Surger",
       "number": "120",
@@ -14863,10 +13075,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14875,19 +13083,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14896,6 +13092,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "121",
       "multiverseid": 136151,
       "name": "Steamflogger Boss",
       "number": "121",
@@ -14909,7 +13106,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Contraption is a new artifact type. There are currently no artifacts with this type. And there's no current game meaning of \"assemble.\""
+          "text": "Contraption is a new artifact type. There are currently no artifacts with this type. And there’s no current game meaning of “assemble.”"
         }
       ],
       "subtypes": [
@@ -14985,10 +13182,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14997,19 +13190,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15018,6 +13199,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "122",
       "multiverseid": 130675,
       "name": "Storm Entity",
       "number": "122",
@@ -15107,10 +13289,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15119,19 +13297,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15140,6 +13306,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}{R}",
+      "mciNumber": "123",
       "multiverseid": 136139,
       "name": "Tarox Bladewing",
       "number": "123",
@@ -15153,7 +13320,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +X/+X bonus is based on Tarox Bladewing's power at the time the ability resolves. It won't change if Tarox's power changes later in the turn."
+          "text": "The +X/+X bonus is based on Tarox Bladewing’s power at the time the ability resolves. It won’t change if Tarox’s power changes later in the turn."
         }
       ],
       "subtypes": [
@@ -15230,10 +13397,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15242,19 +13405,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15263,6 +13414,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "124",
       "multiverseid": 130338,
       "name": "Thunderblade Charge",
       "number": "124",
@@ -15349,10 +13501,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15361,19 +13509,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15382,6 +13518,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "125",
       "multiverseid": 126169,
       "name": "Cyclical Evolution",
       "number": "125",
@@ -15394,39 +13531,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -15500,10 +13637,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15512,19 +13645,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15533,6 +13654,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "126",
       "multiverseid": 130713,
       "name": "Force of Savagery",
       "number": "126",
@@ -15546,7 +13668,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Yes, Force of Savagery has 0 toughness. It will be put into its owner's graveyard as a state-based action immediately upon entering the battlefield unless an effect puts it onto the battlefield with a counter on it (such as Chorus of the Conclave would) or a static ability boosts its toughness (such as Glorious Anthem would). A triggered or activated ability that boosts toughness won't have its effect fast enough to save it."
+          "text": "Yes, Force of Savagery has 0 toughness. It will be put into its owner’s graveyard as a state-based action immediately upon entering the battlefield unless an effect puts it onto the battlefield with a counter on it (such as Chorus of the Conclave would) or a static ability boosts its toughness (such as Glorious Anthem would). A triggered or activated ability that boosts toughness won’t have its effect fast enough to save it."
         }
       ],
       "subtypes": [
@@ -15620,10 +13742,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15632,19 +13750,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15653,6 +13759,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "127",
       "multiverseid": 132216,
       "name": "Heartwood Storyteller",
       "number": "127",
@@ -15733,10 +13840,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15745,19 +13848,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15766,6 +13857,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "128",
       "multiverseid": 132218,
       "name": "Kavu Primarch",
       "number": "128",
@@ -15878,10 +13970,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15890,19 +13978,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15911,6 +13987,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "129",
       "multiverseid": 132213,
       "name": "Llanowar Augur",
       "number": "129",
@@ -15992,23 +14069,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -16020,19 +14085,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "130",
       "multiverseid": 126147,
       "name": "Llanowar Empath",
       "number": "130",
@@ -16115,10 +14173,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16127,19 +14181,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16148,6 +14190,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "131",
       "multiverseid": 126166,
       "name": "Llanowar Mentor",
       "number": "131",
@@ -16230,10 +14273,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16242,19 +14281,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16263,6 +14290,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "132",
       "multiverseid": 136159,
       "name": "Magus of the Vineyard",
       "number": "132",
@@ -16351,10 +14379,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16363,19 +14387,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16384,6 +14396,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "133",
       "multiverseid": 132223,
       "name": "Petrified Plating",
       "number": "133",
@@ -16396,39 +14409,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -16505,10 +14518,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16517,19 +14526,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16538,6 +14535,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "134",
       "multiverseid": 132217,
       "name": "Quiet Disrepair",
       "number": "134",
@@ -16551,11 +14549,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If you choose the \"destroy\" mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
+          "text": "If you choose the “destroy” mode and Quiet Disrepair is moved to a different permanent while the ability is on the stack, the newly enchanted permanent will be destroyed when the ability resolves."
         },
         {
           "date": "2007-05-01",
-          "text": "If you choose the \"destroy\" mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
+          "text": "If you choose the “destroy” mode and Quiet Disrepair leaves the battlefield while the ability is on the stack, the last permanent it enchanted will be destroyed."
         }
       ],
       "subtypes": [
@@ -16627,10 +14625,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16639,19 +14633,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16660,6 +14642,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "135",
       "multiverseid": 130339,
       "name": "Ravaging Riftwurm",
       "number": "135",
@@ -16673,7 +14656,7 @@
       "subtypes": [
         "Wurm"
       ],
-      "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nVanishing 2 (This permanent enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nIf Ravaging Riftwurm was kicked, it enters the battlefield with three additional time counters on it.",
+      "text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nVanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nIf Ravaging Riftwurm was kicked, it enters the battlefield with three additional time counters on it.",
       "toughness": "6",
       "type": "Creature — Wurm",
       "types": [
@@ -16741,10 +14724,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16753,19 +14732,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16774,6 +14741,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "136",
       "multiverseid": 130353,
       "name": "Riftsweeper",
       "number": "136",
@@ -16788,7 +14756,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn't matter why the card was exiled or who owns it."
+          "text": "It doesn’t matter why the card was exiled or who owns it."
         },
         {
           "date": "2007-05-01",
@@ -16796,7 +14764,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If Riftsweeper affects a card that's haunting a creature, the haunt effect ends."
+          "text": "If Riftsweeper affects a card that’s haunting a creature, the haunt effect ends."
         }
       ],
       "subtypes": [
@@ -16871,10 +14839,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16883,19 +14847,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16904,6 +14856,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "137",
       "multiverseid": 130670,
       "name": "Rites of Flourishing",
       "number": "137",
@@ -16986,10 +14939,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16998,19 +14947,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17019,6 +14956,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "138",
       "multiverseid": 136042,
       "name": "Sprout Swarm",
       "number": "138",
@@ -17124,10 +15062,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17136,19 +15070,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17157,6 +15079,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "139",
       "multiverseid": 130706,
       "name": "Summoner's Pact",
       "number": "139",
@@ -17170,7 +15093,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Search your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.\nAt the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.",
@@ -17239,10 +15162,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17251,19 +15170,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17272,6 +15179,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "140",
       "multiverseid": 130616,
       "name": "Utopia Mycon",
       "number": "140",
@@ -17353,10 +15261,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17365,19 +15269,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17386,6 +15278,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "141",
       "multiverseid": 130331,
       "name": "Wrap in Vigor",
       "number": "141",
@@ -17468,10 +15361,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17480,19 +15369,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17501,6 +15378,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "142",
       "multiverseid": 136155,
       "name": "Baru, Fist of Krosa",
       "number": "142",
@@ -17514,11 +15392,11 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The first ability triggers when a Forest enters the battlefield under any player's control, but only your creatures get the bonus."
+          "text": "The first ability triggers when a Forest enters the battlefield under any player’s control, but only your creatures get the bonus."
         },
         {
           "date": "2007-05-01",
-          "text": "The size of the Wurm token is determined when the activated ability resolves. It won't change as the number of lands you control changes."
+          "text": "The size of the Wurm token is determined when the activated ability resolves. It won’t change as the number of lands you control changes."
         }
       ],
       "subtypes": [
@@ -17597,10 +15475,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17609,19 +15483,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17630,6 +15492,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "143",
       "multiverseid": 130684,
       "name": "Centaur Omenreader",
       "number": "143",
@@ -17716,10 +15579,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17728,19 +15587,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17749,6 +15596,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "144",
       "multiverseid": 126132,
       "name": "Edge of Autumn",
       "number": "144",
@@ -17833,10 +15681,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17845,19 +15689,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17866,6 +15698,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "145",
       "multiverseid": 130634,
       "name": "Imperiosaur",
       "number": "145",
@@ -17880,15 +15713,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Mana from any source other than a land with the supertype \"basic\" can't be spent to cast Imperiosaur."
+          "text": "Mana from any source other than a land with the supertype “basic” can’t be spent to cast Imperiosaur."
         },
         {
           "date": "2007-05-01",
-          "text": "Many mana-producing effects (such as Heartbeat of Spring or Utopia Sprawl, for example) add mana to a player's mana pool whenever a land becomes tapped. This mana is produced by the enchantment, not the land, so it can't be used to pay for Imperiosaur."
+          "text": "Many mana-producing effects (such as Heartbeat of Spring or Utopia Sprawl, for example) add mana to a player’s mana pool whenever a land becomes tapped. This mana is produced by the enchantment, not the land, so it can’t be used to pay for Imperiosaur."
         },
         {
           "date": "2007-05-01",
-          "text": "A small number of effects (Pulse of Llanowar and Hall of Gemstone, for example) state that a land \"produces\" certain mana instead of what it would normally produce. If the land is basic, then mana produced this way can be spent to cast Imperiosaur."
+          "text": "A small number of effects (Pulse of Llanowar and Hall of Gemstone, for example) state that a land “produces” certain mana instead of what it would normally produce. If the land is basic, then mana produced this way can be spent to cast Imperiosaur."
         },
         {
           "date": "2007-05-01",
@@ -17896,7 +15729,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Imperiosaur's restriction applies to the total cost to cast it. If there are any additional costs (such as from Feroz's Ban, for example), those costs would have to be paid with mana produced by basic lands as well."
+          "text": "Imperiosaur’s restriction applies to the total cost to cast it. If there are any additional costs (such as from Feroz’s Ban, for example), those costs would have to be paid with mana produced by basic lands as well."
         }
       ],
       "subtypes": [
@@ -17971,10 +15804,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17983,19 +15812,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18004,6 +15821,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "146",
       "multiverseid": 130614,
       "name": "Muraganda Petroglyphs",
       "number": "146",
@@ -18016,15 +15834,15 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Muraganda Petroglyphs gives a bonus only to creatures that have no rules text at all. This includes true vanilla creatures (such as Grizzly Bears), face-down creatures, many tokens, and creatures that have lost their abilities (due to Ovinize, for example). Any ability of any kind, whether or not the ability functions in the on the battlefield zone, including things like \"Cycling {2}\" means the creature doesn't get the bonus."
+          "text": "Muraganda Petroglyphs gives a bonus only to creatures that have no rules text at all. This includes true vanilla creatures (such as Grizzly Bears), face-down creatures, many tokens, and creatures that have lost their abilities (due to Ovinize, for example). Any ability of any kind, whether or not the ability functions in the on the battlefield zone, including things like “Cycling {2}” means the creature doesn’t get the bonus."
         },
         {
           "date": "2007-05-01",
-          "text": "Animated basic lands have mana abilities, so they won't get the bonus."
+          "text": "Animated basic lands have mana abilities, so they won’t get the bonus."
         },
         {
           "date": "2007-05-01",
-          "text": "Some Auras and Equipment grant abilities to creatures, meaning the affected creature would no longer get the +2/+2 bonus. For example, Flight grants flying to the enchanted creature. Other Auras and Equipment do not, meaning the affected creature would continue to get the +2/+2 bonus. For example, Dehydration states something now true about the enchanted creature, but doesn't give it any abilities. Auras and Equipment that grant abilities will use the words \"gains\" or \"has,\" and they'll list a keyword ability or an ability in quotation marks."
+          "text": "Some Auras and Equipment grant abilities to creatures, meaning the affected creature would no longer get the +2/+2 bonus. For example, Flight grants flying to the enchanted creature. Other Auras and Equipment do not, meaning the affected creature would continue to get the +2/+2 bonus. For example, Dehydration states something now true about the enchanted creature, but doesn’t give it any abilities. Auras and Equipment that grant abilities will use the words “gains” or “has,” and they’ll list a keyword ability or an ability in quotation marks."
         },
         {
           "date": "2013-07-01",
@@ -18098,10 +15916,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18110,19 +15924,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18131,6 +15933,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}{G}",
+      "mciNumber": "147",
       "multiverseid": 130588,
       "name": "Nacatl War-Pride",
       "number": "147",
@@ -18144,7 +15947,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If it's impossible for Nacatl War-Pride to be blocked by exactly one creature, then the defending player may block it with multiple creatures or may leave it unblocked."
+          "text": "If it’s impossible for Nacatl War-Pride to be blocked by exactly one creature, then the defending player may block it with multiple creatures or may leave it unblocked."
         },
         {
           "date": "2007-05-01",
@@ -18156,15 +15959,15 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The tokens enter the battlefield attacking, even if the attack couldn't legally be declared."
+          "text": "The tokens enter the battlefield attacking, even if the attack couldn’t legally be declared."
         },
         {
           "date": "2007-05-01",
-          "text": "Putting an attacking creature onto the battlefield doesn't trigger \"When this creature attacks\" abilities. It also won't check attacking restrictions, costs, or requirements."
+          "text": "Putting an attacking creature onto the battlefield doesn’t trigger “When this creature attacks” abilities. It also won’t check attacking restrictions, costs, or requirements."
         },
         {
           "date": "2007-05-01",
-          "text": "In a multiplayer game in which you're allowed to attack only one player each combat, the new creatures will be attacking the same player as Nacatl War-Pride. In a multiplayer game in which you may attack multiple players, you choose the player each new creature is attacking. It must be a player you're allowed to attack."
+          "text": "In a multiplayer game in which you’re allowed to attack only one player each combat, the new creatures will be attacking the same player as Nacatl War-Pride. In a multiplayer game in which you may attack multiple players, you choose the player each new creature is attacking. It must be a player you’re allowed to attack."
         }
       ],
       "subtypes": [
@@ -18239,23 +16042,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -18267,15 +16058,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "148",
       "multiverseid": 136138,
       "name": "Nessian Courser",
       "number": "148",
@@ -18358,10 +16146,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18374,19 +16158,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18395,6 +16167,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}{G}",
+      "mciNumber": "149",
       "multiverseid": 126160,
       "name": "Phosphorescent Feast",
       "number": "149",
@@ -18408,7 +16181,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "Chroma abilities check only mana costs, which are found in a card's upper right corner. They don't count mana symbols that appear in a card's text box."
+          "text": "Chroma abilities check only mana costs, which are found in a card’s upper right corner. They don’t count mana symbols that appear in a card’s text box."
         },
         {
           "date": "2008-08-01",
@@ -18482,10 +16255,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18494,19 +16263,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18515,6 +16272,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "150",
       "multiverseid": 136153,
       "name": "Quagnoth",
       "number": "150",
@@ -18528,7 +16286,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "If Quagnoth is discarded normally (it moves from your hand to your graveyard), its last ability triggers from your graveyard. If Yixlid Jailer is on the battlefield, it won't trigger."
+          "text": "If Quagnoth is discarded normally (it moves from your hand to your graveyard), its last ability triggers from your graveyard. If Yixlid Jailer is on the battlefield, it won’t trigger."
         },
         {
           "date": "2007-05-01",
@@ -18544,23 +16302,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -18635,10 +16393,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18647,19 +16401,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18668,6 +16410,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "151",
       "multiverseid": 130659,
       "name": "Spellwild Ouphe",
       "number": "151",
@@ -18689,7 +16432,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The spell may have any number of other targets; that won't affect the cost reduction unless the spell targets other Spellwild Ouphes as well. In that case, the spell costs {2} less to cast for each different Spellwild Ouphe it targets."
+          "text": "The spell may have any number of other targets; that won’t affect the cost reduction unless the spell targets other Spellwild Ouphes as well. In that case, the spell costs {2} less to cast for each different Spellwild Ouphe it targets."
         }
       ],
       "subtypes": [
@@ -18763,10 +16506,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18775,19 +16514,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18796,6 +16523,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "152",
       "multiverseid": 130323,
       "name": "Sporoloth Ancient",
       "number": "152",
@@ -18888,10 +16616,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18900,19 +16624,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18921,6 +16633,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "153",
       "multiverseid": 136142,
       "name": "Tarmogoyf",
       "number": "153",
@@ -18936,7 +16649,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Tarmogoyf's ability works in all zones, not just while Tarmogoyf is on the battlefield."
+          "text": "Tarmogoyf’s ability works in all zones, not just while Tarmogoyf is on the battlefield."
         },
         {
           "date": "2007-05-01",
@@ -19019,10 +16732,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19031,19 +16740,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19052,6 +16749,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "154",
       "multiverseid": 130630,
       "name": "Thornweald Archer",
       "number": "154",
@@ -19135,10 +16833,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19147,19 +16841,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19168,6 +16850,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "155",
       "multiverseid": 130644,
       "name": "Virulent Sliver",
       "number": "155",
@@ -19263,10 +16946,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19275,19 +16954,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19296,6 +16963,7 @@
         }
       ],
       "manaCost": "{G}{W}",
+      "mciNumber": "156",
       "multiverseid": 136157,
       "name": "Glittering Wish",
       "number": "156",
@@ -19320,11 +16988,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "You can't have Glittering Wish retrieve itself. You can have it retrieve a Glittering Wish from your sideboard."
+          "text": "You can’t have Glittering Wish retrieve itself. You can have it retrieve a Glittering Wish from your sideboard."
         },
         {
           "date": "2009-10-01",
-          "text": "You can't get an exiled card because those cards are still in one of the game zones."
+          "text": "You can’t get an exiled card because those cards are still in one of the game zones."
         }
       ],
       "text": "You may choose a multicolored card you own from outside the game, reveal that card, and put it into your hand. Exile Glittering Wish.",
@@ -19395,10 +17063,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19407,19 +17071,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19428,6 +17080,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "157",
       "multiverseid": 136194,
       "name": "Jhoira of the Ghitu",
       "number": "157",
@@ -19442,31 +17095,31 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -19556,10 +17209,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19568,19 +17217,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19589,6 +17226,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}{R}{G}",
+      "mciNumber": "158",
       "multiverseid": 136146,
       "name": "Sliver Legion",
       "number": "158",
@@ -19681,10 +17319,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19693,19 +17327,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19714,6 +17336,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "159",
       "multiverseid": 136150,
       "name": "Akroma's Memorial",
       "number": "159",
@@ -19788,10 +17411,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19800,19 +17419,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19821,6 +17428,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "160",
       "multiverseid": 136156,
       "name": "Cloud Key",
       "number": "160",
@@ -19890,10 +17498,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19902,19 +17506,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19923,6 +17515,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "161",
       "multiverseid": 125878,
       "name": "Coalition Relic",
       "number": "161",
@@ -20003,10 +17596,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20015,19 +17604,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20036,6 +17613,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "162",
       "multiverseid": 136143,
       "name": "Epochrasite",
       "number": "162",
@@ -20055,39 +17633,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -20160,10 +17738,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20172,19 +17746,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20193,6 +17755,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "163",
       "multiverseid": 130329,
       "name": "Sliversmith",
       "number": "163",
@@ -20268,10 +17831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20280,19 +17839,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20301,6 +17848,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "164",
       "multiverseid": 126213,
       "name": "Soultether Golem",
       "number": "164",
@@ -20314,7 +17862,7 @@
       "subtypes": [
         "Golem"
       ],
-      "text": "Vanishing 1 (This permanent enters the battlefield with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever another creature enters the battlefield under your control, put a time counter on Soultether Golem.",
+      "text": "Vanishing 1 (This creature enters the battlefield with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever another creature enters the battlefield under your control, put a time counter on Soultether Golem.",
       "toughness": "3",
       "type": "Artifact Creature — Golem",
       "types": [
@@ -20376,31 +17924,15 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20409,6 +17941,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "165",
       "multiverseid": 126215,
       "name": "Sword of the Meek",
       "number": "165",
@@ -20421,7 +17954,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The triggered ability checks the power and toughness of a creature that enters the battlefield as it exists once it's on the battlefield. For example, Triskelion has 1/1 printed on it, but it enters the battlefield with three +1/+1 counters on it, so it actually enters the battlefield as a 4/4 creature. Sword of the Meek's ability wouldn't trigger. Ditto for a Llanowar Elves that enters the battlefield while you control Gaea's Anthem."
+          "text": "The triggered ability checks the power and toughness of a creature that enters the battlefield as it exists once it’s on the battlefield. For example, Triskelion has 1/1 printed on it, but it enters the battlefield with three +1/+1 counters on it, so it actually enters the battlefield as a 4/4 creature. Sword of the Meek’s ability wouldn’t trigger. Ditto for a Llanowar Elves that enters the battlefield while you control Gaea’s Anthem."
         },
         {
           "date": "2007-05-01",
@@ -20429,7 +17962,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If multiple 1/1 creatures enter the battlefield at the same time, the Sword's ability will trigger that many times. Only the first ability to resolve will return the Sword to the battlefield and attach it to a creature."
+          "text": "If multiple 1/1 creatures enter the battlefield at the same time, the Sword’s ability will trigger that many times. Only the first ability to resolve will return the Sword to the battlefield and attach it to a creature."
         }
       ],
       "subtypes": [
@@ -20496,10 +18029,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20508,19 +18037,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20529,6 +18046,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "166",
       "multiverseid": 136149,
       "name": "Veilstone Amulet",
       "number": "166",
@@ -20598,10 +18116,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20610,19 +18124,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20631,6 +18133,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "167",
       "multiverseid": 126211,
       "name": "Darksteel Garrison",
       "number": "167",
@@ -20651,11 +18154,11 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The second ability triggers whenever the fortified land becomes tapped, not just when it's tapped for mana."
+          "text": "The second ability triggers whenever the fortified land becomes tapped, not just when it’s tapped for mana."
         },
         {
           "date": "2007-05-01",
-          "text": "The triggered ability is mandatory. If you don't have a creature to target, you must target another player's creature, if possible."
+          "text": "The triggered ability is mandatory. If you don’t have a creature to target, you must target another player’s creature, if possible."
         }
       ],
       "subtypes": [
@@ -20722,10 +18225,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20734,19 +18233,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20755,6 +18242,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "168",
       "multiverseid": 136141,
       "name": "Whetwheel",
       "number": "168",
@@ -20827,10 +18315,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20839,19 +18323,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20859,6 +18331,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "169",
       "multiverseid": 136053,
       "name": "Dakmor Salvage",
       "number": "169",
@@ -20877,11 +18350,11 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Once you decide to replace a draw using a card's dredge ability, that card can't be removed from your graveyard \"in response.\" (Replacement effects don't use the stack.)"
+          "text": "Once you decide to replace a draw using a card’s dredge ability, that card can’t be removed from your graveyard “in response.” (Replacement effects don’t use the stack.)"
         },
         {
           "date": "2013-06-07",
-          "text": "You can't use dredge unless you're going to draw a card and the card with dredge is already in your graveyard."
+          "text": "You can’t use dredge unless you’re going to draw a card and the card with dredge is already in your graveyard."
         }
       ],
       "text": "Dakmor Salvage enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nDredge 2 (If you would draw a card, instead you may put exactly two cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)",
@@ -20946,10 +18419,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20958,19 +18427,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20978,6 +18435,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "170",
       "multiverseid": 136046,
       "name": "Keldon Megaliths",
       "number": "170",
@@ -20992,7 +18450,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "It doesn't matter how many cards you have in your hand when the ability resolves."
+          "text": "It doesn’t matter how many cards you have in your hand when the ability resolves."
         }
       ],
       "text": "Keldon Megaliths enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nHellbent — {1}{R}, {T}: Keldon Megaliths deals 1 damage to target creature or player. Activate this ability only if you have no cards in hand.",
@@ -21057,10 +18515,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21069,19 +18523,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21089,6 +18531,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "171",
       "multiverseid": 136035,
       "name": "Llanowar Reborn",
       "number": "171",
@@ -21105,7 +18548,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The +1/+1 counter won't affect Llanowar Reborn in any way unless another effect turns it into a creature."
+          "text": "The +1/+1 counter won’t affect Llanowar Reborn in any way unless another effect turns it into a creature."
         }
       ],
       "text": "Llanowar Reborn enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nGraft 1 (This land enters the battlefield with a +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this land onto it.)",
@@ -21170,10 +18613,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21182,19 +18621,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21202,6 +18629,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "172",
       "multiverseid": 126198,
       "name": "New Benalia",
       "number": "172",
@@ -21277,10 +18705,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21289,19 +18713,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21309,6 +18721,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "173",
       "multiverseid": 136047,
       "name": "Tolaria West",
       "number": "173",
@@ -21390,10 +18803,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21402,19 +18811,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21422,6 +18819,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "174",
       "multiverseid": 136196,
       "name": "Dryad Arbor",
       "number": "174",
@@ -21440,19 +18838,19 @@
         },
         {
           "date": "2007-05-01",
-          "text": "Dryad Arbor is played as a land. It doesn't use the stack, it's not a spell, it can't be responded to, it has no mana cost, and it counts as your land play for the turn."
+          "text": "Dryad Arbor is played as a land. It doesn’t use the stack, it’s not a spell, it can’t be responded to, it has no mana cost, and it counts as your land play for the turn."
         },
         {
           "date": "2007-05-01",
-          "text": "If a Dryad Arbor gains flash, or you have the ability to play Dryad Arbor as though it had flash (due to Teferi, Mage of Zhalfir or Scout's Warning, for example), you can ignore the normal timing rules for playing a land, but not any other restrictions. You can't play Dryad Arbor during another player's turn, and you can't play Dryad Arbor if it's your turn and you've already played a land."
+          "text": "If a Dryad Arbor gains flash, or you have the ability to play Dryad Arbor as though it had flash (due to Teferi, Mage of Zhalfir or Scout’s Warning, for example), you can ignore the normal timing rules for playing a land, but not any other restrictions. You can’t play Dryad Arbor during another player’s turn, and you can’t play Dryad Arbor if it’s your turn and you’ve already played a land."
         },
         {
           "date": "2011-09-22",
-          "text": "If Dryad Arbor is changed into another basic land type (such as by Sea's Claim), it continues to be a creature and a Dryad."
+          "text": "If Dryad Arbor is changed into another basic land type (such as by Sea’s Claim), it continues to be a creature and a Dryad."
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "subtypes": [
@@ -21526,10 +18924,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21542,19 +18936,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21562,6 +18944,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "175",
       "multiverseid": 130581,
       "name": "Graven Cairns",
       "number": "175",
@@ -21576,7 +18959,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "{(b/r)}, {T}\" is the same as saying \"{B}, {T} or {R}, {T}."
+          "text": "{(b/r)}, {T}” is the same as saying “{B}, {T} or {R}, {T}."
         }
       ],
       "text": "{T}: Add {C} to your mana pool.\n{B/R}, {T}: Add {B}{B}, {B}{R}, or {R}{R} to your mana pool.",
@@ -21644,10 +19027,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21656,19 +19035,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21676,6 +19043,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "176",
       "multiverseid": 130595,
       "name": "Grove of the Burnwillows",
       "number": "176",
@@ -21751,10 +19119,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21763,19 +19127,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21783,6 +19135,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "177",
       "multiverseid": 130574,
       "name": "Horizon Canopy",
       "number": "177",
@@ -21858,10 +19211,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21870,19 +19219,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21890,6 +19227,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "178",
       "multiverseid": 136045,
       "name": "Nimbus Maze",
       "number": "178",
@@ -21964,10 +19302,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21976,19 +19310,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21996,6 +19318,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "179",
       "multiverseid": 126210,
       "name": "River of Tears",
       "number": "179",
@@ -22012,7 +19335,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "The land produces {B} only after you've played a land, not after you've put a land directly onto the battlefield (such as with Rampant Growth)."
+          "text": "The land produces {B} only after you’ve played a land, not after you’ve put a land directly onto the battlefield (such as with Rampant Growth)."
         }
       ],
       "text": "{T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.",
@@ -22076,10 +19399,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22088,19 +19407,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22108,6 +19415,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "180",
       "multiverseid": 132215,
       "name": "Zoetic Cavern",
       "number": "180",

--- a/json/PLC.json
+++ b/json/PLC.json
@@ -26,6 +26,18 @@
       "timeshifted uncommon"
     ]
   ],
+  "translations": {
+    "de": "Weltenchaos",
+    "fr": "Chaos planaire",
+    "it": "Caos Dimensionale",
+    "es": "Caos planar",
+    "pt": "Caos Planar",
+    "jp": "次元の混乱",
+    "cn": "时空混沌",
+    "ru": "Вселенский Хаос"
+  },
+  "mkm_name": "Planar Chaos",
+  "mkm_id": 58,
   "cards": [
     {
       "artist": "Don Hazeltine",
@@ -87,10 +99,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -99,19 +107,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -120,6 +116,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "1",
       "multiverseid": 108899,
       "name": "Aven Riftwatcher",
       "number": "1",
@@ -135,7 +132,7 @@
         "Rebel",
         "Soldier"
       ],
-      "text": "Flying\nVanishing 3 (This permanent enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher enters the battlefield or leaves the battlefield, you gain 2 life.",
+      "text": "Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Aven Riftwatcher enters the battlefield or leaves the battlefield, you gain 2 life.",
       "toughness": "3",
       "type": "Creature — Bird Rebel Soldier",
       "types": [
@@ -202,10 +199,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -214,19 +207,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -235,6 +216,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "2",
       "multiverseid": 122408,
       "name": "Benalish Commander",
       "number": "2",
@@ -252,43 +234,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -367,10 +349,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -379,19 +357,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -400,6 +366,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 122487,
       "name": "Crovax, Ascendant Hero",
       "number": "3",
@@ -489,10 +456,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -501,19 +464,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -522,6 +473,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "4",
       "multiverseid": 124080,
       "name": "Dawn Charm",
       "number": "4",
@@ -534,7 +486,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Dawn Charm's third mode can target a spell that has multiple targets, as long as at least one of those targets is you."
+          "text": "Dawn Charm’s third mode can target a spell that has multiple targets, as long as at least one of those targets is you."
         }
       ],
       "text": "Choose one —\n• Prevent all combat damage that would be dealt this turn.\n• Regenerate target creature.\n• Counter target spell that targets you.",
@@ -603,10 +555,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -615,19 +563,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -636,6 +572,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "5",
       "multiverseid": 124343,
       "name": "Dust Elemental",
       "number": "5",
@@ -649,15 +586,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "You may return this creature itself to its owner's hand. If you control no other creatures, you must return it."
+          "text": "You may return this creature itself to its owner’s hand. If you control no other creatures, you must return it."
         },
         {
           "date": "2007-02-01",
-          "text": "The ability doesn't target what you return. You don't choose what to return until the ability resolves. No one can respond to the choice."
+          "text": "The ability doesn’t target what you return. You don’t choose what to return until the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2007-02-01",
-          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner's hand."
+          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner’s hand."
         }
       ],
       "subtypes": [
@@ -731,10 +668,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -743,19 +676,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -764,6 +685,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "6",
       "multiverseid": 126809,
       "name": "Ghost Tactician",
       "number": "6",
@@ -845,10 +767,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -857,19 +775,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -878,6 +784,7 @@
         }
       ],
       "manaCost": "{6}{W}{W}{W}",
+      "mciNumber": "7",
       "multiverseid": 122438,
       "name": "Heroes Remembered",
       "number": "7",
@@ -890,39 +797,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -996,10 +903,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1008,19 +911,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1029,6 +920,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "8",
       "multiverseid": 130719,
       "name": "Magus of the Tabernacle",
       "number": "8",
@@ -1110,10 +1002,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1122,19 +1010,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1143,6 +1019,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "9",
       "multiverseid": 122349,
       "name": "Mantle of Leadership",
       "number": "9",
@@ -1221,10 +1098,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1233,19 +1106,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1254,6 +1115,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "10",
       "multiverseid": 124508,
       "name": "Pallid Mycoderm",
       "number": "10",
@@ -1268,7 +1130,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Pallid Mycoderm gives a creature that's both a Saproling and a Fungus (such as Mistform Ultimus) +1/+1, not +2/+2."
+          "text": "Pallid Mycoderm gives a creature that’s both a Saproling and a Fungus (such as Mistform Ultimus) +1/+1, not +2/+2."
         }
       ],
       "subtypes": [
@@ -1342,10 +1204,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1354,19 +1212,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1375,6 +1221,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "11",
       "multiverseid": 126014,
       "name": "Poultice Sliver",
       "number": "11",
@@ -1466,10 +1313,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1478,19 +1321,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1499,6 +1330,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "12",
       "multiverseid": 122287,
       "name": "Rebuff the Wicked",
       "number": "12",
@@ -1581,10 +1413,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1593,19 +1421,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1614,6 +1430,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "13",
       "multiverseid": 131007,
       "name": "Retether",
       "number": "13",
@@ -1626,11 +1443,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "All the Auras return to the battlefield simultaneously. Whether an Aura can be attached to a creature is checked before any of them are returned and doesn't take into account any simultaneously returning Auras. For example, if Tattoo Ward (which gives enchanted creature protection from enchantments) and Holy Strength are in your graveyard and there's only one creature on the battlefield, both Auras are returned to the battlefield attached to that creature, then Holy Strength is put into your graveyard the next time state-based actions are checked."
+          "text": "All the Auras return to the battlefield simultaneously. Whether an Aura can be attached to a creature is checked before any of them are returned and doesn’t take into account any simultaneously returning Auras. For example, if Tattoo Ward (which gives enchanted creature protection from enchantments) and Holy Strength are in your graveyard and there’s only one creature on the battlefield, both Auras are returned to the battlefield attached to that creature, then Holy Strength is put into your graveyard the next time state-based actions are checked."
         },
         {
           "date": "2007-02-01",
-          "text": "Auras don't need to say \"enchant creature\" to return to the battlefield. For example, an Aura with \"enchant land\" will return to the battlefield if there's an animated land for it to enchant."
+          "text": "Auras don’t need to say “enchant creature” to return to the battlefield. For example, an Aura with “enchant land” will return to the battlefield if there’s an animated land for it to enchant."
         }
       ],
       "text": "Return each Aura card from your graveyard to the battlefield. Only creatures can be enchanted this way. (Aura cards that can't enchant a creature on the battlefield remain in your graveyard.)",
@@ -1699,10 +1516,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1711,19 +1524,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1732,6 +1533,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "14",
       "multiverseid": 126816,
       "name": "Riftmarked Knight",
       "number": "14",
@@ -1745,43 +1547,43 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If Riftmarked Knight is suspended, then when the last time counter is removed from it, both its own triggered ability and the \"cast this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If Riftmarked Knight is suspended, then when the last time counter is removed from it, both its own triggered ability and the “cast this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1861,10 +1663,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1873,19 +1671,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1894,6 +1680,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "15",
       "multiverseid": 122435,
       "name": "Saltblast",
       "number": "15",
@@ -1971,10 +1758,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1983,19 +1766,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2004,6 +1775,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "16",
       "multiverseid": 124037,
       "name": "Saltfield Recluse",
       "number": "16",
@@ -2088,10 +1860,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2100,19 +1868,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2121,6 +1877,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "17",
       "multiverseid": 129014,
       "name": "Serra's Boon",
       "number": "17",
@@ -2201,10 +1958,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2213,19 +1966,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2234,6 +1975,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "18",
       "multiverseid": 126408,
       "name": "Shade of Trokair",
       "number": "18",
@@ -2247,39 +1989,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -2356,10 +2098,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2368,19 +2106,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2389,6 +2115,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "19",
       "multiverseid": 122469,
       "name": "Stonecloaker",
       "number": "19",
@@ -2408,11 +2135,11 @@
         },
         {
           "date": "2007-02-01",
-          "text": "You may return this creature itself to its owner's hand. If you control no other creatures, you must return it."
+          "text": "You may return this creature itself to its owner’s hand. If you control no other creatures, you must return it."
         },
         {
           "date": "2007-02-01",
-          "text": "The ability doesn't target what you return. You don't choose what to return until the ability resolves. No one can respond to the choice."
+          "text": "The ability doesn’t target what you return. You don’t choose what to return until the ability resolves. No one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2485,10 +2212,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2497,19 +2220,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2518,6 +2229,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "20",
       "multiverseid": 122412,
       "name": "Stormfront Riders",
       "number": "20",
@@ -2544,19 +2256,19 @@
         },
         {
           "date": "2007-02-01",
-          "text": "You may return this creature itself to its owner's hand. If you control no other creatures, you must return it."
+          "text": "You may return this creature itself to its owner’s hand. If you control no other creatures, you must return it."
         },
         {
           "date": "2007-02-01",
-          "text": "The ability doesn't target what you return. You don't choose what to return until the ability resolves. No one can respond to the choice."
+          "text": "The ability doesn’t target what you return. You don’t choose what to return until the ability resolves. No one can respond to the choice."
         },
         {
           "date": "2007-02-01",
-          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner's hand."
+          "text": "If you are instructed to return more creatures than you control, you must return all the creatures you control to their owner’s hand."
         },
         {
           "date": "2009-10-01",
-          "text": "A token's owner is the player under whose control it entered the battlefield."
+          "text": "A token’s owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -2630,10 +2342,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2642,19 +2350,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2663,6 +2359,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "21",
       "multiverseid": 125882,
       "name": "Voidstone Gargoyle",
       "number": "21",
@@ -2684,7 +2381,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can't be cast. The other half is unaffected."
+          "text": "You can name either half of a split card, but not both. If you do so, that half (and both halves, if the split card has fuse) can’t be cast. The other half is unaffected."
         },
         {
           "date": "2007-02-01",
@@ -2696,7 +2393,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder texts."
         }
       ],
       "subtypes": [
@@ -2770,10 +2467,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2782,19 +2475,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2803,6 +2484,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "22",
       "multiverseid": 122477,
       "name": "Whitemane Lion",
       "number": "22",
@@ -2818,11 +2500,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "You may return this creature itself to its owner's hand. If you control no other creatures, you must return it."
+          "text": "You may return this creature itself to its owner’s hand. If you control no other creatures, you must return it."
         },
         {
           "date": "2007-02-01",
-          "text": "The ability doesn't target what you return. You don't choose what to return until the ability resolves. No one can respond to the choice."
+          "text": "The ability doesn’t target what you return. You don’t choose what to return until the ability resolves. No one can respond to the choice."
         }
       ],
       "subtypes": [
@@ -2895,10 +2577,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2907,19 +2585,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2928,6 +2594,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "23",
       "multiverseid": 122360,
       "name": "Calciderm",
       "number": "23",
@@ -2948,7 +2615,7 @@
       "subtypes": [
         "Beast"
       ],
-      "text": "Shroud (This creature can't be the target of spells or abilities.)\nVanishing 4 (This permanent enters the battlefield with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
+      "text": "Shroud (This creature can't be the target of spells or abilities.)\nVanishing 4 (This creature enters the battlefield with four time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
       "timeshifted": true,
       "toughness": "5",
       "type": "Creature — Beast",
@@ -3017,10 +2684,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3029,19 +2692,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3050,6 +2701,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "24",
       "multiverseid": 122481,
       "name": "Malach of the Dawn",
       "number": "24",
@@ -3138,10 +2790,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3150,19 +2798,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3171,6 +2807,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "25",
       "multiverseid": 122324,
       "name": "Mana Tithe",
       "number": "25",
@@ -3259,10 +2896,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3271,19 +2904,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3292,6 +2913,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "26",
       "multiverseid": 126214,
       "name": "Mesa Enchantress",
       "number": "26",
@@ -3316,15 +2938,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can't be changed."
+          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can’t be changed."
         },
         {
           "date": "2007-02-01",
-          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they'll still deal damage."
+          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they’ll still deal damage."
         },
         {
           "date": "2009-10-01",
-          "text": "If you cast an enchantment spell, Mesa Enchantress's ability triggers and is put on the stack on top of that spell. Mesa Enchantress's ability will resolve before the spell does."
+          "text": "If you cast an enchantment spell, Mesa Enchantress’s ability triggers and is put on the stack on top of that spell. Mesa Enchantress’s ability will resolve before the spell does."
         }
       ],
       "subtypes": [
@@ -3399,10 +3021,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3411,19 +3029,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3432,6 +3038,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "27",
       "multiverseid": 124033,
       "name": "Mycologist",
       "number": "27",
@@ -3520,10 +3127,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3532,19 +3135,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3553,6 +3144,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "28",
       "multiverseid": 124470,
       "name": "Porphyry Nodes",
       "number": "28",
@@ -3565,7 +3157,7 @@
       "rulings": [
         {
           "date": "2006-07-15",
-          "text": "This card's ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
+          "text": "This card’s ability is not targeted, so even untargetable creatures or those with Protection can be chosen."
         },
         {
           "date": "2007-02-01",
@@ -3577,7 +3169,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can't be chosen."
+          "text": "If there are multiple creatures tied for least power and some but not all of them have indestructible, the ones with indestructible can’t be chosen."
         }
       ],
       "text": "At the beginning of your upkeep, destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them.\nWhen there are no creatures on the battlefield, sacrifice Porphyry Nodes.",
@@ -3648,10 +3240,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3660,19 +3248,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3681,6 +3257,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "29",
       "multiverseid": 122282,
       "name": "Revered Dead",
       "number": "29",
@@ -3770,10 +3347,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3782,19 +3355,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3803,6 +3364,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "30",
       "multiverseid": 125879,
       "name": "Sinew Sliver",
       "number": "30",
@@ -3903,10 +3465,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3915,19 +3473,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3936,6 +3482,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "31",
       "multiverseid": 122355,
       "name": "Sunlance",
       "number": "31",
@@ -4021,10 +3568,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4033,19 +3576,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4054,6 +3585,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "32",
       "multiverseid": 122449,
       "name": "Aeon Chronicler",
       "number": "32",
@@ -4072,43 +3604,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4185,10 +3717,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4197,19 +3725,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4218,6 +3734,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "33",
       "multiverseid": 126024,
       "name": "Aquamorph Entity",
       "number": "33",
@@ -4232,7 +3749,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The first ability is a replacement effect. The choice is made as Aquamorph Entity is turned face up (or enters the battlefield); it turns face up (or enters the battlefield) as a creature of that size. It doesn't become a 0/0 and then a creature of the chosen size."
+          "text": "The first ability is a replacement effect. The choice is made as Aquamorph Entity is turned face up (or enters the battlefield); it turns face up (or enters the battlefield) as a creature of that size. It doesn’t become a 0/0 and then a creature of the chosen size."
         },
         {
           "date": "2007-02-01",
@@ -4240,7 +3757,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If a creature that's already on the battlefield becomes a copy of a face-up Aquamorph Entity, its power and toughness become the power and toughness that were chosen for the Entity."
+          "text": "If a creature that’s already on the battlefield becomes a copy of a face-up Aquamorph Entity, its power and toughness become the power and toughness that were chosen for the Entity."
         }
       ],
       "subtypes": [
@@ -4314,10 +3831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4326,19 +3839,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4347,6 +3848,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "34",
       "multiverseid": 130813,
       "name": "Auramancer's Guise",
       "number": "34",
@@ -4359,7 +3861,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Auramancer's Guise counts itself when determining the power and toughness bonus."
+          "text": "Auramancer’s Guise counts itself when determining the power and toughness bonus."
         }
       ],
       "subtypes": [
@@ -4432,10 +3934,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4444,19 +3942,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4465,6 +3951,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "35",
       "multiverseid": 124443,
       "name": "Body Double",
       "number": "35",
@@ -4479,11 +3966,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Treat Body Double as though it were the chosen card entering the battlefield. Any \"As this card enters the battlefield,\" \"This card enters the battlefield with,\" and \"When this card enters the battlefield\" abilities of the chosen card will work."
+          "text": "Treat Body Double as though it were the chosen card entering the battlefield. Any “As this card enters the battlefield,” “This card enters the battlefield with,” and “When this card enters the battlefield” abilities of the chosen card will work."
         },
         {
           "date": "2007-02-01",
-          "text": "You don't have to choose a card to copy. If you don't, Body Double enters the battlefield as a 0/0 creature and is probably put into your graveyard immediately, unless something is increasing its toughness to keep it alive."
+          "text": "You don’t have to choose a card to copy. If you don’t, Body Double enters the battlefield as a 0/0 creature and is probably put into your graveyard immediately, unless something is increasing its toughness to keep it alive."
         },
         {
           "date": "2007-02-01",
@@ -4561,10 +4048,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4573,19 +4056,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4594,6 +4065,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "36",
       "multiverseid": 124316,
       "name": "Braids, Conjurer Adept",
       "number": "36",
@@ -4678,10 +4150,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4690,19 +4158,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4711,6 +4167,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "37",
       "multiverseid": 111066,
       "name": "Chronozoa",
       "number": "37",
@@ -4724,11 +4181,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The ability checks to see if Chronozoa had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn't necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
+          "text": "The ability checks to see if Chronozoa had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn’t necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
         },
         {
           "date": "2007-02-01",
-          "text": "Chronozoa's last ability creates two Chronozoa tokens that each enter the battlefield with three time counters and have all of Chronozoa's abilities."
+          "text": "Chronozoa’s last ability creates two Chronozoa tokens that each enter the battlefield with three time counters and have all of Chronozoa’s abilities."
         },
         {
           "date": "2007-02-01",
@@ -4738,7 +4195,7 @@
       "subtypes": [
         "Illusion"
       ],
-      "text": "Flying\nVanishing 3 (This permanent enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Chronozoa dies, if it had no time counters on it, put two tokens that are copies of it onto the battlefield.",
+      "text": "Flying\nVanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Chronozoa dies, if it had no time counters on it, put two tokens that are copies of it onto the battlefield.",
       "toughness": "3",
       "type": "Creature — Illusion",
       "types": [
@@ -4805,10 +4262,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4817,19 +4270,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4838,6 +4279,7 @@
         }
       ],
       "manaCost": "{7}{U}{U}",
+      "mciNumber": "38",
       "multiverseid": 122455,
       "name": "Dichotomancy",
       "number": "38",
@@ -4850,43 +4292,43 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The cards all enter the battlefield simultaneously. If one of the cards that's entering the battlefield is an Aura, it must enter the battlefield attached to a permanent already on the battlefield. It can't enter the battlefield attached to another permanent entering the battlefield via Dichotomancy. If an Aura can't enter the battlefield this way, it remains in the opponent's library."
+          "text": "The cards all enter the battlefield simultaneously. If one of the cards that’s entering the battlefield is an Aura, it must enter the battlefield attached to a permanent already on the battlefield. It can’t enter the battlefield attached to another permanent entering the battlefield via Dichotomancy. If an Aura can’t enter the battlefield this way, it remains in the opponent’s library."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4960,10 +4402,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4972,19 +4410,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4993,6 +4419,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "39",
       "multiverseid": 129022,
       "name": "Dismal Failure",
       "number": "39",
@@ -5069,10 +4496,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5081,19 +4504,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5102,6 +4513,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "40",
       "multiverseid": 134743,
       "name": "Dreamscape Artist",
       "number": "40",
@@ -5183,10 +4595,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5195,19 +4603,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5216,6 +4612,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "41",
       "multiverseid": 124476,
       "name": "Erratic Mutation",
       "number": "41",
@@ -5229,7 +4626,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The target creature is chosen as the spell is cast. You don't reveal cards until the spell resolves."
+          "text": "The target creature is chosen as the spell is cast. You don’t reveal cards until the spell resolves."
         },
         {
           "date": "2007-02-01",
@@ -5302,10 +4699,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5314,19 +4707,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5335,6 +4716,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "42",
       "multiverseid": 124482,
       "name": "Jodah's Avenger",
       "number": "42",
@@ -5416,10 +4798,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5428,19 +4806,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5449,6 +4815,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "43",
       "multiverseid": 131008,
       "name": "Magus of the Bazaar",
       "number": "43",
@@ -5531,10 +4898,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5543,19 +4906,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5564,6 +4915,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "44",
       "multiverseid": 129015,
       "name": "Pongify",
       "number": "44",
@@ -5577,7 +4929,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The creature's controller gets the Ape token even if the creature isn't actually destroyed."
+          "text": "The creature’s controller gets the Ape token even if the creature isn’t actually destroyed."
         }
       ],
       "text": "Destroy target creature. It can't be regenerated. Its controller puts a 3/3 green Ape creature token onto the battlefield.",
@@ -5646,10 +4998,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5658,19 +5006,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5679,6 +5015,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "45",
       "multiverseid": 125880,
       "name": "Reality Acid",
       "number": "45",
@@ -5691,7 +5028,7 @@
       "subtypes": [
         "Aura"
       ],
-      "text": "Enchant permanent\nVanishing 3 (This permanent enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves the battlefield, enchanted permanent's controller sacrifices it.",
+      "text": "Enchant permanent\nVanishing 3 (This Aura enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Reality Acid leaves the battlefield, enchanted permanent's controller sacrifices it.",
       "type": "Enchantment — Aura",
       "types": [
         "Enchantment"
@@ -5757,10 +5094,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5769,19 +5102,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5790,6 +5111,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "46",
       "multiverseid": 122375,
       "name": "Shaper Parasite",
       "number": "46",
@@ -5877,10 +5199,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5889,19 +5207,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5910,6 +5216,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "47",
       "multiverseid": 122459,
       "name": "Spellshift",
       "number": "47",
@@ -5922,15 +5229,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If the targeted spell can't be countered, it remains on the stack and the rest of Spellshift's effect continues to happen."
+          "text": "If the targeted spell can’t be countered, it remains on the stack and the rest of Spellshift’s effect continues to happen."
         },
         {
           "date": "2007-02-01",
-          "text": "If the revealed instant or sorcery card isn't cast, it gets shuffled back into the library."
+          "text": "If the revealed instant or sorcery card isn’t cast, it gets shuffled back into the library."
         },
         {
           "date": "2007-02-01",
-          "text": "If there are no instant or sorcery cards in the player's library, the entire library is revealed and then shuffled."
+          "text": "If there are no instant or sorcery cards in the player’s library, the entire library is revealed and then shuffled."
         }
       ],
       "text": "Counter target instant or sorcery spell. Its controller reveals cards from the top of his or her library until he or she reveals an instant or sorcery card. That player may cast that card without paying its mana cost. Then he or she shuffles his or her library.",
@@ -6000,10 +5307,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6012,19 +5315,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6033,6 +5324,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "48",
       "multiverseid": 124044,
       "name": "Synchronous Sliver",
       "number": "48",
@@ -6123,10 +5415,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6135,19 +5423,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6156,6 +5432,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "49",
       "multiverseid": 130814,
       "name": "Tidewalker",
       "number": "49",
@@ -6169,17 +5446,17 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Unless something is boosting Tidewalker's toughness, when the last time counter is removed, it will be put into the graveyard as a state-based action for having 0 toughness before it can be sacrificed as the result of vanishing."
+          "text": "Unless something is boosting Tidewalker’s toughness, when the last time counter is removed, it will be put into the graveyard as a state-based action for having 0 toughness before it can be sacrificed as the result of vanishing."
         },
         {
           "date": "2007-02-01",
-          "text": "If you don't control any Islands when Tidewalker enters the battlefield, its vanishing ability has no effect. (It enters the battlefield with no time counters on it, so neither of the vanishing triggers can trigger. See \"Vanishing\" in the General Notes section above.) On the other hand, it will be 0/0 and will be put into its owner's graveyard unless something is boosting its toughness."
+          "text": "If you don’t control any Islands when Tidewalker enters the battlefield, its vanishing ability has no effect. (It enters the battlefield with no time counters on it, so neither of the vanishing triggers can trigger. See “Vanishing” in the General Notes section above.) On the other hand, it will be 0/0 and will be put into its owner’s graveyard unless something is boosting its toughness."
         }
       ],
       "subtypes": [
         "Elemental"
       ],
-      "text": "Tidewalker enters the battlefield with a time counter on it for each Island you control.\nVanishing (At the beginning of your upkeep, remove a time counter from this permanent. When the last is removed, sacrifice it.)\nTidewalker's power and toughness are each equal to the number of time counters on it.",
+      "text": "Tidewalker enters the battlefield with a time counter on it for each Island you control.\nVanishing (At the beginning of your upkeep, remove a time counter from this creature. When the last is removed, sacrifice it.)\nTidewalker's power and toughness are each equal to the number of time counters on it.",
       "toughness": "*",
       "type": "Creature — Elemental",
       "types": [
@@ -6246,10 +5523,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6258,19 +5531,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6279,6 +5540,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "50",
       "multiverseid": 122370,
       "name": "Timebender",
       "number": "50",
@@ -6292,7 +5554,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The mode and target of the triggered ability are chosen when it's put on the stack."
+          "text": "The mode and target of the triggered ability are chosen when it’s put on the stack."
         }
       ],
       "subtypes": [
@@ -6366,10 +5628,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6378,19 +5636,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6399,6 +5645,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "51",
       "multiverseid": 126806,
       "name": "Veiling Oddity",
       "number": "51",
@@ -6412,51 +5659,51 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If Veiling Oddity is suspended, then when the last time counter is removed from it, both its triggered ability and the \"cast this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If Veiling Oddity is suspended, then when the last time counter is removed from it, both its triggered ability and the “cast this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2007-02-01",
-          "text": "Regardless of which order those abilities resolve in, Veiling Oddity can't be blocked that turn. The ability affects all creatures, not just the creatures that were on the battlefield when it resolved."
+          "text": "Regardless of which order those abilities resolve in, Veiling Oddity can’t be blocked that turn. The ability affects all creatures, not just the creatures that were on the battlefield when it resolved."
         },
         {
           "date": "2007-02-01",
-          "text": "If Veiling Oddity is suspended and the last time counter is removed during another player's turn, that player's creatures can't be blocked that turn, too."
+          "text": "If Veiling Oddity is suspended and the last time counter is removed during another player’s turn, that player’s creatures can’t be blocked that turn, too."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6534,10 +5781,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6546,19 +5789,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6567,6 +5798,7 @@
         }
       ],
       "manaCost": "{X}{U}",
+      "mciNumber": "52",
       "multiverseid": 126216,
       "name": "Venarian Glimmer",
       "number": "52",
@@ -6649,10 +5881,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6661,19 +5889,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6682,6 +5898,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "53",
       "multiverseid": 124055,
       "name": "Wistful Thinking",
       "number": "53",
@@ -6758,10 +5975,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6770,19 +5983,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6791,6 +5992,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "54",
       "multiverseid": 122402,
       "name": "Frozen Æther",
       "number": "54",
@@ -6819,7 +6021,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "It applies to cards and tokens that are put onto the battlefield by an effect, as well as ones that are played from the player's hand."
+          "text": "It applies to cards and tokens that are put onto the battlefield by an effect, as well as ones that are played from the player’s hand."
         }
       ],
       "text": "Artifacts, creatures, and lands your opponents control enter the battlefield tapped.",
@@ -6890,10 +6092,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6902,19 +6100,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6923,6 +6109,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "55",
       "multiverseid": 122280,
       "name": "Gossamer Phantasm",
       "number": "55",
@@ -7015,10 +6202,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7027,19 +6210,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7048,6 +6219,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "56",
       "multiverseid": 125877,
       "name": "Merfolk Thaumaturgist",
       "number": "56",
@@ -7069,7 +6241,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -7145,10 +6317,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7157,19 +6325,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7178,6 +6334,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "57",
       "multiverseid": 126212,
       "name": "Ovinize",
       "number": "57",
@@ -7190,7 +6347,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Ovinize doesn't counter abilities that have already triggered or been activated. In particular, you can't cast this fast enough to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering, since they trigger before players get priority."
+          "text": "Ovinize doesn’t counter abilities that have already triggered or been activated. In particular, you can’t cast this fast enough to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering, since they trigger before players get priority."
         },
         {
           "date": "2007-02-01",
@@ -7198,15 +6355,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If a face-down creature is affected by Ovinize, it won't be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/1 creature with no abilities until the turn ends. Its \"When this creature turns face up\" or \"As this creature turns face up\" abilities won't work."
+          "text": "If a face-down creature is affected by Ovinize, it won’t be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/1 creature with no abilities until the turn ends. Its “When this creature turns face up” or “As this creature turns face up” abilities won’t work."
         },
         {
           "date": "2007-02-01",
-          "text": "Ovinize can be used to disable a creature's vanishing ability permanently by casting it in response to the vanishing upkeep trigger when there's one time counter left. The last time counter will be removed as that ability resolves, but since the creature no longer has vanishing, the \"sacrifice\" triggered ability won't exist. When Ovinize's effect ends and the creature regains vanishing, its triggered ability will no longer be able to trigger because it has no time counters."
+          "text": "Ovinize can be used to disable a creature’s vanishing ability permanently by casting it in response to the vanishing upkeep trigger when there’s one time counter left. The last time counter will be removed as that ability resolves, but since the creature no longer has vanishing, the “sacrifice” triggered ability won’t exist. When Ovinize’s effect ends and the creature regains vanishing, its triggered ability will no longer be able to trigger because it has no time counters."
         },
         {
           "date": "2007-02-01",
-          "text": "If Ovinize affects Mistform Ultimus, the Ultimus will lose its ability that says \"Mistform Ultimus is every creature type,\" but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus's type-changing ability is applied before Ovinize's ability removes it."
+          "text": "If Ovinize affects Mistform Ultimus, the Ultimus will lose its ability that says “Mistform Ultimus is every creature type,” but it will still *be* all creature types. The way continuous effects work, Mistform Ultimus’s type-changing ability is applied before Ovinize’s ability removes it."
         },
         {
           "date": "2007-02-01",
@@ -7284,10 +6441,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7296,19 +6449,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7317,6 +6458,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "58",
       "multiverseid": 124066,
       "name": "Piracy Charm",
       "number": "58",
@@ -7400,10 +6542,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7412,19 +6550,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7433,6 +6559,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "59",
       "multiverseid": 124757,
       "name": "Primal Plasma",
       "number": "59",
@@ -7448,7 +6575,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If a creature that's already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
+          "text": "If a creature that’s already on the battlefield becomes a copy of Primal Plasma, it copies the power, toughness, and abilities that were chosen for Primal Plasma when it entered the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -7460,7 +6587,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won't necessarily have the same power, toughness, and abilities as the original."
+          "text": "If another permanent enters the battlefield as a copy of Primal Clay, the controller of that permanent will get to make a new choice. The copy won’t necessarily have the same power, toughness, and abilities as the original."
         }
       ],
       "subtypes": [
@@ -7535,10 +6662,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7547,19 +6670,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7568,6 +6679,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "60",
       "multiverseid": 122325,
       "name": "Riptide Pilferer",
       "number": "60",
@@ -7657,10 +6769,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7669,19 +6777,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7690,6 +6786,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "61",
       "multiverseid": 122442,
       "name": "Serendib Sorcerer",
       "number": "61",
@@ -7779,10 +6876,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7791,19 +6884,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7812,6 +6893,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "62",
       "multiverseid": 125873,
       "name": "Serra Sphinx",
       "number": "62",
@@ -7899,10 +6981,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7911,19 +6989,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7932,6 +6998,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "63",
       "multiverseid": 134739,
       "name": "Big Game Hunter",
       "number": "63",
@@ -7947,7 +7014,7 @@
         "Rebel",
         "Assassin"
       ],
-      "text": "When Big Game Hunter enters the battlefield, destroy target creature with power 4 or greater. It can't be regenerated.\nMadness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "When Big Game Hunter enters the battlefield, destroy target creature with power 4 or greater. It can't be regenerated.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "1",
       "type": "Creature — Human Rebel Assassin",
       "types": [
@@ -8015,10 +7082,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8027,19 +7090,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8048,6 +7099,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "64",
       "multiverseid": 124506,
       "name": "Blightspeaker",
       "number": "64",
@@ -8132,10 +7184,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8144,19 +7192,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8165,6 +7201,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "65",
       "multiverseid": 124040,
       "name": "Brain Gorgers",
       "number": "65",
@@ -8178,7 +7215,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -8186,13 +7223,13 @@
         },
         {
           "date": "2013-07-01",
-          "text": "A player can't choose to sacrifice a creature unless he or she actually controls a creature that can be sacrificed. For example, if the action were \"discard three cards,\" a player with two or fewer cards in hand couldn't take the option to counter the spell."
+          "text": "A player can’t choose to sacrifice a creature unless he or she actually controls a creature that can be sacrificed. For example, if the action were “discard three cards,” a player with two or fewer cards in hand couldn’t take the option to counter the spell."
         }
       ],
       "subtypes": [
         "Zombie"
       ],
-      "text": "When you cast Brain Gorgers, any player may sacrifice a creature. If a player does, counter Brain Gorgers.\nMadness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "When you cast Brain Gorgers, any player may sacrifice a creature. If a player does, counter Brain Gorgers.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "2",
       "type": "Creature — Zombie",
       "types": [
@@ -8259,10 +7296,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8271,19 +7304,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8292,6 +7313,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "66",
       "multiverseid": 126803,
       "name": "Circle of Affliction",
       "number": "66",
@@ -8304,15 +7326,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The player you target doesn't have to be the controller of the source that dealt damage to you."
+          "text": "The player you target doesn’t have to be the controller of the source that dealt damage to you."
         },
         {
           "date": "2007-02-01",
-          "text": "If the damage reduces you to 0 or less life, you lose the game before Circle of Affliction's ability has a chance to give you life."
+          "text": "If the damage reduces you to 0 or less life, you lose the game before Circle of Affliction’s ability has a chance to give you life."
         },
         {
           "date": "2007-02-01",
-          "text": "Each time a source deals damage to you, you may pay {1}. You can't pay more than {1}, even if more than 1 damage was dealt."
+          "text": "Each time a source deals damage to you, you may pay {1}. You can’t pay more than {1}, even if more than 1 damage was dealt."
         },
         {
           "date": "2007-02-01",
@@ -8386,10 +7408,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8398,19 +7416,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8419,6 +7425,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "67",
       "multiverseid": 110536,
       "name": "Cradle to Grave",
       "number": "67",
@@ -8495,10 +7502,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8507,19 +7510,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8528,6 +7519,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "68",
       "multiverseid": 126812,
       "name": "Dash Hopes",
       "number": "68",
@@ -8540,7 +7532,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -8548,7 +7540,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "A player can't choose to pay 5 life unless he or she actually has 5 or more life to pay."
+          "text": "A player can’t choose to pay 5 life unless he or she actually has 5 or more life to pay."
         }
       ],
       "text": "When you cast Dash Hopes, any player may pay 5 life. If a player does, counter Dash Hopes.\nCounter target spell.",
@@ -8617,10 +7609,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8629,19 +7617,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8650,6 +7626,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "69",
       "multiverseid": 111046,
       "name": "Deadly Grub",
       "number": "69",
@@ -8663,13 +7640,13 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The ability checks to see if Deadly Grub had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn't necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
+          "text": "The ability checks to see if Deadly Grub had no time counters on it at the time it was put into a graveyard from the battlefield. This doesn’t necessarily mean it must have been sacrificed due to vanishing; it could have been put into the graveyard some other way (say, while the sacrifice ability of vanishing is on the stack)."
         }
       ],
       "subtypes": [
         "Insect"
       ],
-      "text": "Vanishing 3 (This permanent enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadly Grub dies, if it had no time counters on it, put a 6/1 green Insect creature token with shroud onto the battlefield. (It can't be the target of spells or abilities.)",
+      "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadly Grub dies, if it had no time counters on it, put a 6/1 green Insect creature token with shroud onto the battlefield. (It can't be the target of spells or abilities.)",
       "toughness": "1",
       "type": "Creature — Insect",
       "types": [
@@ -8736,10 +7713,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8748,23 +7721,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Scars of Mirrodin Block",
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8773,6 +7734,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "70",
       "multiverseid": 122413,
       "name": "Enslave",
       "number": "70",
@@ -8788,11 +7750,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn't start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
+          "text": "The owner of a card is the player who started the game with that card in his or her deck. If the card didn’t start the game in a deck, its owner is the player who brought the card into the game, via Living Wish or a similar effect."
         },
         {
           "date": "2009-10-01",
-          "text": "A token's owner is the player under whose control it entered the battlefield."
+          "text": "A token’s owner is the player under whose control it entered the battlefield."
         }
       ],
       "subtypes": [
@@ -8864,10 +7826,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8876,19 +7834,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8897,6 +7843,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "71",
       "multiverseid": 126804,
       "name": "Extirpate",
       "number": "71",
@@ -8914,23 +7861,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nChoose target card in a graveyard other than a basic land card. Search its owner's graveyard, hand, and library for all cards with the same name as that card and exile them. Then that player shuffles his or her library.",
@@ -9000,10 +7947,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9012,19 +7955,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9033,6 +7964,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "72",
       "multiverseid": 122434,
       "name": "Imp's Mischief",
       "number": "72",
@@ -9057,7 +7989,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can't make a spell which is on the stack target itself."
+          "text": "You can’t make a spell which is on the stack target itself."
         },
         {
           "date": "2004-10-04",
@@ -9077,15 +8009,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If there is no other legal target for the spell, the spell's target isn't changed. You still lose the life."
+          "text": "If there is no other legal target for the spell, the spell’s target isn’t changed. You still lose the life."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can't target it with Imp's Mischief, even if all but one of the targets has become illegal."
+          "text": "If a spell targets multiple things, you can’t target it with Imp’s Mischief, even if all but one of the targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets but is targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can't target that spell with Imp's Mischief."
+          "text": "If a spell has multiple targets but is targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can’t target that spell with Imp’s Mischief."
         }
       ],
       "text": "Change the target of target spell with a single target. You lose life equal to that spell's converted mana cost.",
@@ -9155,10 +8087,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9167,19 +8095,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9188,6 +8104,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "73",
       "multiverseid": 124507,
       "name": "Magus of the Coffers",
       "number": "73",
@@ -9270,10 +8187,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9282,19 +8195,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9303,6 +8204,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "74",
       "multiverseid": 124034,
       "name": "Midnight Charm",
       "number": "74",
@@ -9379,10 +8281,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9391,19 +8289,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9412,6 +8298,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "75",
       "multiverseid": 122406,
       "name": "Mirri the Cursed",
       "number": "75",
@@ -9425,7 +8312,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If Mirri the Cursed is in combat with a creature that doesn't have first strike or double strike, Mirri will deal combat damage to that creature, then get a +1/+1 counter, then (if the other creature is still on the battlefield) Mirri will be dealt combat damage."
+          "text": "If Mirri the Cursed is in combat with a creature that doesn’t have first strike or double strike, Mirri will deal combat damage to that creature, then get a +1/+1 counter, then (if the other creature is still on the battlefield) Mirri will be dealt combat damage."
         }
       ],
       "subtypes": [
@@ -9502,10 +8389,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9514,19 +8397,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9535,6 +8406,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "76",
       "multiverseid": 122478,
       "name": "Muck Drubb",
       "number": "76",
@@ -9548,21 +8420,21 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The spell's target is changed to Muck Drubb only if Muck Drubb is a legal target for that spell."
+          "text": "The spell’s target is changed to Muck Drubb only if Muck Drubb is a legal target for that spell."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can't target it with Muck Drubb's ability, even if only one of those targets is a creature or all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can’t target it with Muck Drubb’s ability, even if only one of those targets is a creature or all but one of those targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets, but it's targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can target that spell with Muck Drubb's ability. In that case, you change all of those targets to Muck Drubb."
+          "text": "If a spell has multiple targets, but it’s targeting the same thing with all of them (such as Seeds of Strength targeting the same creature three times), you can target that spell with Muck Drubb’s ability. In that case, you change all of those targets to Muck Drubb."
         }
       ],
       "subtypes": [
         "Beast"
       ],
-      "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Muck Drubb enters the battlefield, change the target of target spell that targets only a single creature to Muck Drubb.\nMadness {2}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Flash (You may cast this spell any time you could cast an instant.)\nWhen Muck Drubb enters the battlefield, change the target of target spell that targets only a single creature to Muck Drubb.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "3",
       "type": "Creature — Beast",
       "types": [
@@ -9629,10 +8501,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9641,19 +8509,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9662,6 +8518,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "77",
       "multiverseid": 124472,
       "name": "Phantasmagorian",
       "number": "77",
@@ -9675,7 +8532,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -9683,7 +8540,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "A player can't choose to discard unless he or she actually has three cards in his or her hand."
+          "text": "A player can’t choose to discard unless he or she actually has three cards in his or her hand."
         }
       ],
       "subtypes": [
@@ -9757,10 +8614,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9769,19 +8622,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9790,6 +8631,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "78",
       "multiverseid": 130717,
       "name": "Ridged Kusite",
       "number": "78",
@@ -9871,10 +8713,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9883,19 +8721,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9904,6 +8730,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "79",
       "multiverseid": 122431,
       "name": "Roiling Horror",
       "number": "79",
@@ -9917,11 +8744,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If your life total is less than or equal to the life total of the opponent with the most life, Roiling Horror's toughness is 0 or less. It will be put into its owner's graveyard as a state-based action."
+          "text": "If your life total is less than or equal to the life total of the opponent with the most life, Roiling Horror’s toughness is 0 or less. It will be put into its owner’s graveyard as a state-based action."
         },
         {
           "date": "2007-02-01",
-          "text": "You never choose an opponent, and the opponent that Roiling Horror looks at is never \"locked in.\" Roiling Horror continuously looks at the life totals of all opponents and uses whichever value is the largest."
+          "text": "You never choose an opponent, and the opponent that Roiling Horror looks at is never “locked in.” Roiling Horror continuously looks at the life totals of all opponents and uses whichever value is the largest."
         },
         {
           "date": "2007-02-01",
@@ -9929,43 +8756,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -10043,10 +8870,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10055,19 +8878,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10076,6 +8887,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "80",
       "multiverseid": 126022,
       "name": "Spitting Sliver",
       "number": "80",
@@ -10167,10 +8979,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10179,19 +8987,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10200,6 +8996,7 @@
         }
       ],
       "manaCost": "{B}{B}{B}{B}",
+      "mciNumber": "81",
       "multiverseid": 126814,
       "name": "Temporal Extortion",
       "number": "81",
@@ -10212,7 +9009,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When this spell is cast, its \"when you cast\" ability triggers and goes on the stack on top of it."
+          "text": "When this spell is cast, its “when you cast” ability triggers and goes on the stack on top of it."
         },
         {
           "date": "2007-02-01",
@@ -10285,10 +9082,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10297,19 +9090,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10318,6 +9099,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "82",
       "multiverseid": 131002,
       "name": "Treacherous Urge",
       "number": "82",
@@ -10330,11 +9112,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If you don't control the creature when the ability resolves, the creature won't be sacrificed. It will have haste permanently."
+          "text": "If you don’t control the creature when the ability resolves, the creature won’t be sacrificed. It will have haste permanently."
         },
         {
           "date": "2007-02-01",
-          "text": "If you cast Treacherous Urge during the End step, you won't sacrifice the creature until the end of the following turn."
+          "text": "If you cast Treacherous Urge during the End step, you won’t sacrifice the creature until the end of the following turn."
         }
       ],
       "text": "Target opponent reveals his or her hand. You may put a creature card from it onto the battlefield under your control. That creature gains haste. Sacrifice it at the beginning of the next end step.",
@@ -10403,10 +9185,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10415,19 +9193,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10436,6 +9202,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "83",
       "multiverseid": 110503,
       "name": "Waning Wurm",
       "number": "83",
@@ -10450,7 +9217,7 @@
         "Zombie",
         "Wurm"
       ],
-      "text": "Vanishing 2 (This permanent enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
+      "text": "Vanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)",
       "toughness": "6",
       "type": "Creature — Zombie Wurm",
       "types": [
@@ -10518,10 +9285,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10530,19 +9293,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10551,6 +9302,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "84",
       "multiverseid": 122321,
       "name": "Bog Serpent",
       "number": "84",
@@ -10638,10 +9390,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10650,19 +9398,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10671,6 +9407,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "85",
       "multiverseid": 122423,
       "name": "Damnation",
       "number": "85",
@@ -10755,10 +9492,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10767,19 +9500,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10788,6 +9509,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "86",
       "multiverseid": 128940,
       "name": "Dunerider Outlaw",
       "number": "86",
@@ -10809,7 +9531,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Dunerider Outlaw's triggered ability checks to see if it dealt damage during the turn to an opponent of its current controller. If it dealt damage to player A, then player A takes control of it, the ability doesn't trigger."
+          "text": "Dunerider Outlaw’s triggered ability checks to see if it dealt damage during the turn to an opponent of its current controller. If it dealt damage to player A, then player A takes control of it, the ability doesn’t trigger."
         },
         {
           "date": "2007-02-01",
@@ -10894,10 +9616,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10906,19 +9624,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10927,6 +9633,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "87",
       "multiverseid": 131006,
       "name": "Kor Dirge",
       "number": "87",
@@ -11009,10 +9716,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11021,19 +9724,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11042,6 +9733,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "88",
       "multiverseid": 130714,
       "name": "Melancholy",
       "number": "88",
@@ -11128,10 +9820,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11140,19 +9828,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11161,6 +9837,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "89",
       "multiverseid": 125874,
       "name": "Null Profusion",
       "number": "89",
@@ -11173,7 +9850,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The triggered ability will trigger when you play a land card or cast a nonland card as a spell. It won't trigger when you play a copy of a card, such as with Isochron Scepter."
+          "text": "The triggered ability will trigger when you play a land card or cast a nonland card as a spell. It won’t trigger when you play a copy of a card, such as with Isochron Scepter."
         },
         {
           "date": "2007-02-01",
@@ -11260,10 +9937,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11272,19 +9945,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11293,6 +9954,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "90",
       "multiverseid": 130718,
       "name": "Rathi Trapper",
       "number": "90",
@@ -11383,10 +10045,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11395,19 +10053,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11416,6 +10062,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "91",
       "multiverseid": 122285,
       "name": "Shrouded Lore",
       "number": "91",
@@ -11428,7 +10075,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "You target an opponent when you cast Shrouded Lore. The opponent chooses a card in your graveyard as Shrouded Lore resolves. After that choice is made, you're given the option to pay {B}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn't one, this part is skipped.) Then you're given the option to pay {B} again. As long as you keep paying {B}, the process continues. As soon as you decline to pay {B}, the last card that was chosen by the opponent is put into your hand."
+          "text": "You target an opponent when you cast Shrouded Lore. The opponent chooses a card in your graveyard as Shrouded Lore resolves. After that choice is made, you’re given the option to pay {B}. If you do, the targeted opponent must choose a different card, if there is one. (If there isn’t one, this part is skipped.) Then you’re given the option to pay {B} again. As long as you keep paying {B}, the process continues. As soon as you decline to pay {B}, the last card that was chosen by the opponent is put into your hand."
         },
         {
           "date": "2007-02-01",
@@ -11507,10 +10154,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11519,19 +10162,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11540,6 +10171,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "92",
       "multiverseid": 122366,
       "name": "Vampiric Link",
       "number": "92",
@@ -11633,10 +10265,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11645,19 +10273,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11666,6 +10282,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "93",
       "multiverseid": 124504,
       "name": "Æther Membrane",
       "number": "93",
@@ -11680,7 +10297,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The blocked creature is returned to its owner's hand at end of combat only if the blocked creature is still on the battlefield. It doesn't matter whether AEther Membrane is on the battlefield."
+          "text": "The blocked creature is returned to its owner’s hand at end of combat only if the blocked creature is still on the battlefield. It doesn’t matter whether AEther Membrane is on the battlefield."
         }
       ],
       "subtypes": [
@@ -11753,10 +10370,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11765,19 +10378,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11786,6 +10387,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}{R}",
+      "mciNumber": "94",
       "multiverseid": 122432,
       "name": "Akroma, Angel of Fury",
       "number": "94",
@@ -11886,10 +10488,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11898,19 +10496,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11919,6 +10505,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "95",
       "multiverseid": 126015,
       "name": "Battering Sliver",
       "number": "95",
@@ -12009,10 +10596,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12021,19 +10604,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12042,6 +10613,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "96",
       "multiverseid": 126811,
       "name": "Detritivore",
       "number": "96",
@@ -12063,43 +10635,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -12177,10 +10749,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12189,19 +10757,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12210,6 +10766,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "97",
       "multiverseid": 110501,
       "name": "Dust Corona",
       "number": "97",
@@ -12222,7 +10779,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don't actually have Flying."
+          "text": "Creatures with the Reach ability (such as Giant Spider) can block this because they don’t actually have Flying."
         }
       ],
       "subtypes": [
@@ -12295,10 +10852,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12307,19 +10860,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12328,6 +10869,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "98",
       "multiverseid": 124748,
       "name": "Fatal Frenzy",
       "number": "98",
@@ -12340,7 +10882,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If you don't control the affected creature at end of turn, it isn't sacrificed."
+          "text": "If you don’t control the affected creature at end of turn, it isn’t sacrificed."
         }
       ],
       "text": "Until end of turn, target creature you control gains trample and gets +X/+0, where X is its power. Sacrifice it at the beginning of the next end step.",
@@ -12410,10 +10952,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12422,19 +10960,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12443,6 +10969,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "99",
       "multiverseid": 130720,
       "name": "Firefright Mage",
       "number": "99",
@@ -12524,10 +11051,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12536,19 +11059,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12557,6 +11068,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "100",
       "multiverseid": 124039,
       "name": "Fury Charm",
       "number": "100",
@@ -12633,10 +11145,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12645,19 +11153,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12666,6 +11162,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "101",
       "multiverseid": 128948,
       "name": "Hammerheim Deadeye",
       "number": "101",
@@ -12748,10 +11245,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12760,19 +11253,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12781,6 +11262,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "102",
       "multiverseid": 125885,
       "name": "Keldon Marauders",
       "number": "102",
@@ -12796,7 +11278,7 @@
         "Human",
         "Warrior"
       ],
-      "text": "Vanishing 2 (This permanent enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Keldon Marauders enters the battlefield or leaves the battlefield, it deals 1 damage to target player.",
+      "text": "Vanishing 2 (This creature enters the battlefield with two time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Keldon Marauders enters the battlefield or leaves the battlefield, it deals 1 damage to target player.",
       "toughness": "3",
       "type": "Creature — Human Warrior",
       "types": [
@@ -12863,10 +11345,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12875,19 +11353,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12896,6 +11362,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "103",
       "multiverseid": 111055,
       "name": "Lavacore Elemental",
       "number": "103",
@@ -12909,7 +11376,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If multiple creatures you control deal combat damage to a player, Lavacore Elemental's ability triggers that many times."
+          "text": "If multiple creatures you control deal combat damage to a player, Lavacore Elemental’s ability triggers that many times."
         },
         {
           "date": "2007-02-01",
@@ -12919,7 +11386,7 @@
       "subtypes": [
         "Elemental"
       ],
-      "text": "Vanishing 1 (This permanent enters the battlefield with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever a creature you control deals combat damage to a player, put a time counter on Lavacore Elemental.",
+      "text": "Vanishing 1 (This creature enters the battlefield with a time counter on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhenever a creature you control deals combat damage to a player, put a time counter on Lavacore Elemental.",
       "toughness": "3",
       "type": "Creature — Elemental",
       "types": [
@@ -12987,10 +11454,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12999,19 +11462,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13020,6 +11471,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "104",
       "multiverseid": 134746,
       "name": "Magus of the Arena",
       "number": "104",
@@ -13038,15 +11490,15 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Magus of the Arena's controller always chooses his or her creature first."
+          "text": "Magus of the Arena’s controller always chooses his or her creature first."
         },
         {
           "date": "2007-02-01",
-          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can't be changed."
+          "text": "If an effect changes the targets of this ability, the second target can be changed to any creature the chosen opponent controls. The choice of opponent can’t be changed."
         },
         {
           "date": "2007-02-01",
-          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they'll still deal damage."
+          "text": "Tapped creatures can be targeted. Tapping them again will do nothing, but they’ll still deal damage."
         }
       ],
       "subtypes": [
@@ -13121,10 +11573,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13133,19 +11581,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13154,6 +11590,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "105",
       "multiverseid": 122268,
       "name": "Needlepeak Spider",
       "number": "105",
@@ -13234,10 +11671,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13246,19 +11679,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13267,6 +11688,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "106",
       "multiverseid": 134740,
       "name": "Shivan Meteor",
       "number": "106",
@@ -13279,39 +11701,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -13384,10 +11806,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13396,19 +11814,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13417,6 +11823,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "107",
       "multiverseid": 134744,
       "name": "Stingscourger",
       "number": "107",
@@ -13499,10 +11906,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13511,19 +11914,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13532,6 +11923,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "108",
       "multiverseid": 122416,
       "name": "Sulfur Elemental",
       "number": "108",
@@ -13549,23 +11941,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -13639,10 +12031,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13651,19 +12039,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13672,6 +12048,7 @@
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "109",
       "multiverseid": 129012,
       "name": "Timecrafting",
       "number": "109",
@@ -13747,10 +12124,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13759,19 +12132,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13780,6 +12141,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "110",
       "multiverseid": 126810,
       "name": "Torchling",
       "number": "110",
@@ -13794,15 +12156,15 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When the third ability resolves, you must change the target if able. If you can't choose a legal target for the spell when this ability resolves, that spell's target doesn't change."
+          "text": "When the third ability resolves, you must change the target if able. If you can’t choose a legal target for the spell when this ability resolves, that spell’s target doesn’t change."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell targets multiple things, you can't target it with Torchling's third ability, even if all but one of those targets has become illegal."
+          "text": "If a spell targets multiple things, you can’t target it with Torchling’s third ability, even if all but one of those targets has become illegal."
         },
         {
           "date": "2007-02-01",
-          "text": "If a spell has multiple targets, but it's targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling's third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell's targeting conditions."
+          "text": "If a spell has multiple targets, but it’s targeting Torchling with all of them (such as Seeds of Strength targeting Torchling three times), you can target that spell with Torchling’s third ability. In that case, you change all of those targets to the same new target, as long as it meets each of the spell’s targeting conditions."
         }
       ],
       "subtypes": [
@@ -13875,10 +12237,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13887,19 +12245,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13908,6 +12254,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "111",
       "multiverseid": 126303,
       "name": "Volcano Hellion",
       "number": "111",
@@ -13921,11 +12268,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "As Volcano Hellion's enters-the-battlefield ability resolves, you choose a number. Volcano Hellion deals that amount of damage to you and to the targeted creature. You may choose 0."
+          "text": "As Volcano Hellion’s enters-the-battlefield ability resolves, you choose a number. Volcano Hellion deals that amount of damage to you and to the targeted creature. You may choose 0."
         },
         {
           "date": "2007-02-01",
-          "text": "Volcano Hellion's echo cost constantly changes; it's not locked in when it enters the battlefield. The echo cost you pay is equal your life total as the echo triggered ability resolves."
+          "text": "Volcano Hellion’s echo cost constantly changes; it’s not locked in when it enters the battlefield. The echo cost you pay is equal your life total as the echo triggered ability resolves."
         }
       ],
       "subtypes": [
@@ -13998,10 +12345,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14010,19 +12353,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14031,6 +12362,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "112a",
       "multiverseid": 126218,
       "name": "Boom",
       "names": [
@@ -14110,10 +12442,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14122,19 +12450,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14143,6 +12459,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "112b",
       "multiverseid": 126218,
       "name": "Bust",
       "names": [
@@ -14222,10 +12539,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14234,19 +12547,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14255,6 +12556,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "113a",
       "multiverseid": 126419,
       "name": "Dead",
       "names": [
@@ -14334,10 +12636,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14346,19 +12644,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14367,6 +12653,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "113b",
       "multiverseid": 126419,
       "name": "Gone",
       "names": [
@@ -14446,10 +12733,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14458,19 +12741,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14479,6 +12750,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "114a",
       "multiverseid": 126420,
       "name": "Rough",
       "names": [
@@ -14559,10 +12831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14571,19 +12839,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14592,6 +12848,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "114b",
       "multiverseid": 126420,
       "name": "Tumble",
       "names": [
@@ -14673,10 +12930,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14685,19 +12938,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14706,6 +12947,7 @@
         }
       ],
       "manaCost": "{R}{R}",
+      "mciNumber": "115",
       "multiverseid": 130715,
       "name": "Blood Knight",
       "number": "115",
@@ -14796,10 +13038,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14808,19 +13046,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14829,6 +13055,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "116",
       "multiverseid": 122373,
       "name": "Brute Force",
       "number": "116",
@@ -14913,10 +13140,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14925,19 +13148,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14946,6 +13157,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "117",
       "multiverseid": 134738,
       "name": "Molten Firebird",
       "number": "117",
@@ -14959,7 +13171,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The player who controlled Molten Firebird when it was put into a graveyard will skip his or her next draw step even if Molten Firebird is returned to the battlefield under a different player's control (because it's owned by someone else) or isn't returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
+          "text": "The player who controlled Molten Firebird when it was put into a graveyard will skip his or her next draw step even if Molten Firebird is returned to the battlefield under a different player’s control (because it’s owned by someone else) or isn’t returned to the battlefield at all (because it left the graveyard before the end of the turn, for example)."
         },
         {
           "date": "2007-02-01",
@@ -15042,10 +13254,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15054,19 +13262,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15075,6 +13271,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "118",
       "multiverseid": 122338,
       "name": "Prodigal Pyromancer",
       "number": "118",
@@ -15167,10 +13364,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15179,19 +13372,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15200,6 +13381,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "119",
       "multiverseid": 122436,
       "name": "Pyrohemia",
       "number": "119",
@@ -15221,7 +13403,7 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Note that \"until end of turn\" effects wear off after \"at the beginning of the end step\" triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
+          "text": "Note that “until end of turn” effects wear off after “at the beginning of the end step” triggered abilities, so an artifact that animates until end of turn can keep this on the battlefield."
         },
         {
           "date": "2011-06-01",
@@ -15296,10 +13478,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15308,19 +13486,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15329,6 +13495,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "120",
       "multiverseid": 126818,
       "name": "Reckless Wurm",
       "number": "120",
@@ -15349,7 +13516,7 @@
       "subtypes": [
         "Wurm"
       ],
-      "text": "Trample\nMadness {2}{R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Trample\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "timeshifted": true,
       "toughness": "4",
       "type": "Creature — Wurm",
@@ -15418,10 +13585,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15430,19 +13593,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15451,6 +13602,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "121",
       "multiverseid": 124445,
       "name": "Shivan Wumpus",
       "number": "121",
@@ -15464,7 +13616,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "When Shivan Wumpus enters the battlefield, first the active player gets the option to sacrifice a land. If he or she declines, the next player in turn order gets the option. If a player elects to sacrifice a land, Shivan Wumpus is put on top of its owner's library, but then all remaining players still get the option. If all players decline, then nothing happens and Shivan Wumpus stays on the battlefield."
+          "text": "When Shivan Wumpus enters the battlefield, first the active player gets the option to sacrifice a land. If he or she declines, the next player in turn order gets the option. If a player elects to sacrifice a land, Shivan Wumpus is put on top of its owner’s library, but then all remaining players still get the option. If all players decline, then nothing happens and Shivan Wumpus stays on the battlefield."
         },
         {
           "date": "2007-02-01",
@@ -15543,10 +13695,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15555,19 +13703,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15576,6 +13712,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "122",
       "multiverseid": 124474,
       "name": "Simian Spirit Guide",
       "number": "122",
@@ -15669,10 +13806,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15681,19 +13814,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15702,6 +13823,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "123",
       "multiverseid": 131011,
       "name": "Skirk Shaman",
       "number": "123",
@@ -15794,10 +13916,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15806,19 +13924,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15827,6 +13933,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "124",
       "multiverseid": 124342,
       "name": "Ana Battlemage",
       "number": "124",
@@ -15915,10 +14022,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15927,19 +14030,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15948,6 +14039,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "125",
       "multiverseid": 122290,
       "name": "Citanul Woodreaders",
       "number": "125",
@@ -16030,10 +14122,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16042,19 +14130,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16063,6 +14139,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "126",
       "multiverseid": 109740,
       "name": "Deadwood Treefolk",
       "number": "126",
@@ -16078,7 +14155,7 @@
       "subtypes": [
         "Treefolk"
       ],
-      "text": "Vanishing 3 (This permanent enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk enters the battlefield or leaves the battlefield, return another target creature card from your graveyard to your hand.",
+      "text": "Vanishing 3 (This creature enters the battlefield with three time counters on it. At the beginning of your upkeep, remove a time counter from it. When the last is removed, sacrifice it.)\nWhen Deadwood Treefolk enters the battlefield or leaves the battlefield, return another target creature card from your graveyard to your hand.",
       "toughness": "6",
       "type": "Creature — Treefolk",
       "types": [
@@ -16145,10 +14222,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16157,19 +14230,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16178,6 +14239,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "127",
       "multiverseid": 124047,
       "name": "Evolution Charm",
       "number": "127",
@@ -16253,10 +14315,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16265,19 +14323,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16286,6 +14332,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "128",
       "multiverseid": 124065,
       "name": "Fungal Behemoth",
       "number": "128",
@@ -16307,43 +14354,43 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the \"play this card\" part of the suspend ability will trigger. They can be put on the stack in either order."
+          "text": "If this is suspended, then when the last time counter is removed from it, both its triggered ability and the “play this card” part of the suspend ability will trigger. They can be put on the stack in either order."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -16420,10 +14467,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16432,19 +14475,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16453,6 +14484,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "129",
       "multiverseid": 122313,
       "name": "Giant Dustwasp",
       "number": "129",
@@ -16467,39 +14499,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -16576,10 +14608,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16588,19 +14616,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16609,6 +14625,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "130",
       "multiverseid": 122458,
       "name": "Hunting Wilds",
       "number": "130",
@@ -16625,7 +14642,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "A noncreature permanent that turns into a creature is subject to the \"summoning sickness\" rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
+          "text": "A noncreature permanent that turns into a creature is subject to the “summoning sickness” rule: It can only attack, and its {T} abilities can only be activated, if its controller has continuously controlled that permanent since the beginning of his or her most recent turn."
         }
       ],
       "text": "Kicker {3}{G} (You may pay an additional {3}{G} as you cast this spell.)\nSearch your library for up to two Forest cards and put them onto the battlefield tapped. Then shuffle your library.\nIf Hunting Wilds was kicked, untap all Forests put onto the battlefield this way. They become 3/3 green creatures with haste that are still lands.",
@@ -16695,10 +14712,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16707,19 +14720,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16728,6 +14729,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}{G}",
+      "mciNumber": "131",
       "multiverseid": 124344,
       "name": "Jedit Ojanen of Efrava",
       "number": "131",
@@ -16819,10 +14821,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16831,19 +14829,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16852,6 +14838,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "132",
       "multiverseid": 126813,
       "name": "Kavu Predator",
       "number": "132",
@@ -16934,10 +14921,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16946,19 +14929,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16967,6 +14938,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "133",
       "multiverseid": 124471,
       "name": "Life and Limb",
       "number": "133",
@@ -16987,11 +14959,11 @@
         },
         {
           "date": "2007-02-01",
-          "text": "Forests that enter the battlefield while Life and Limb is on the battlefield will enter the battlefield as creatures. They'll have summoning sickness."
+          "text": "Forests that enter the battlefield while Life and Limb is on the battlefield will enter the battlefield as creatures. They’ll have summoning sickness."
         },
         {
           "date": "2007-02-01",
-          "text": "Saprolings that are on the battlefield while Life and Limb is on the battlefield have the ability \"{T}: Add {G} to your mana pool.\" Although they're Forests, they are not basic lands."
+          "text": "Saprolings that are on the battlefield while Life and Limb is on the battlefield have the ability “{T}: Add {G} to your mana pool.” Although they’re Forests, they are not basic lands."
         },
         {
           "date": "2007-02-01",
@@ -17065,10 +15037,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17077,19 +15045,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17098,6 +15054,7 @@
         }
       ],
       "manaCost": "{G}{G}",
+      "mciNumber": "134",
       "multiverseid": 134741,
       "name": "Magus of the Library",
       "number": "134",
@@ -17186,10 +15143,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17198,19 +15151,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17219,6 +15160,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "135",
       "multiverseid": 122420,
       "name": "Mire Boa",
       "number": "135",
@@ -17299,10 +15241,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17311,19 +15249,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17332,6 +15258,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "136",
       "multiverseid": 122323,
       "name": "Pouncing Wurm",
       "number": "136",
@@ -17418,10 +15345,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17430,19 +15353,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17451,6 +15362,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "137",
       "multiverseid": 128944,
       "name": "Psychotrope Thallid",
       "number": "137",
@@ -17532,10 +15444,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17544,19 +15452,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17565,6 +15461,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "138",
       "multiverseid": 126018,
       "name": "Reflex Sliver",
       "number": "138",
@@ -17656,10 +15553,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17668,19 +15561,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17689,6 +15570,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "139",
       "multiverseid": 124505,
       "name": "Sophic Centaur",
       "number": "139",
@@ -17771,10 +15653,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17783,19 +15661,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17804,6 +15670,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "140",
       "multiverseid": 124478,
       "name": "Timbermare",
       "number": "140",
@@ -17885,10 +15752,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17897,19 +15760,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17918,6 +15769,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "141",
       "multiverseid": 126306,
       "name": "Uktabi Drake",
       "number": "141",
@@ -17999,10 +15851,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18011,19 +15859,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18032,6 +15868,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "142",
       "multiverseid": 131004,
       "name": "Utopia Vow",
       "number": "142",
@@ -18110,10 +15947,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18122,19 +15955,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18143,6 +15964,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "143",
       "multiverseid": 128941,
       "name": "Vitaspore Thallid",
       "number": "143",
@@ -18223,10 +16045,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18235,19 +16053,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18256,6 +16062,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "144",
       "multiverseid": 122468,
       "name": "Wild Pair",
       "number": "144",
@@ -18273,7 +16080,7 @@
         },
         {
           "date": "2007-02-01",
-          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it's impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
+          "text": "The game checks the power and toughness of the creature that just entered the battlefield as it exists on the battlefield. That might mean it’s impossible to get another copy of that same card. For example, a Triskelion on the battlefield is 4/4, but a Triskelion in your library is 1/1. The power and toughness might also have been affected while the triggered ability was on the stack (such as with Giant Growth, Sudden Death, or Ovinize)."
         },
         {
           "date": "2007-02-01",
@@ -18351,10 +16158,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18363,19 +16166,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18384,6 +16175,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "145",
       "multiverseid": 122428,
       "name": "Essence Warden",
       "number": "145",
@@ -18483,10 +16275,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18495,19 +16283,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18516,6 +16292,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "146",
       "multiverseid": 122374,
       "name": "Fa'adiyah Seer",
       "number": "146",
@@ -18529,7 +16306,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "If the draw is replaced by another effect, none of the rest of Fa'adiyah Seer's ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
+          "text": "If the draw is replaced by another effect, none of the rest of Fa’adiyah Seer’s ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
         },
         {
           "date": "2007-02-01",
@@ -18613,10 +16390,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18625,19 +16398,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18646,6 +16407,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "147",
       "multiverseid": 122367,
       "name": "Gaea's Anthem",
       "number": "147",
@@ -18729,10 +16491,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18741,19 +16499,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18762,6 +16508,7 @@
         }
       ],
       "manaCost": "{G}{G}{G}",
+      "mciNumber": "148",
       "multiverseid": 122429,
       "name": "Groundbreaker",
       "number": "148",
@@ -18855,10 +16602,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18867,19 +16610,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18888,6 +16619,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "149",
       "multiverseid": 122362,
       "name": "Harmonize",
       "number": "149",
@@ -18979,10 +16711,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18991,19 +16719,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19012,6 +16728,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "150",
       "multiverseid": 122371,
       "name": "Healing Leaves",
       "number": "150",
@@ -19096,10 +16813,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19108,19 +16821,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19129,6 +16830,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "151",
       "multiverseid": 122405,
       "name": "Hedge Troll",
       "number": "151",
@@ -19219,10 +16921,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19231,19 +16929,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19252,6 +16938,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "152",
       "multiverseid": 122451,
       "name": "Keen Sense",
       "number": "152",
@@ -19272,11 +16959,11 @@
         },
         {
           "date": "2007-02-01",
-          "text": "If put on your opponent's creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
+          "text": "If put on your opponent’s creature, you do not draw a card when that creature damages you. The creature has to damage your opponent in order to have this work."
         },
         {
           "date": "2007-02-01",
-          "text": "Drawing a card is optional. If you forget, you can't go back later and do it, even if it is something you normally do."
+          "text": "Drawing a card is optional. If you forget, you can’t go back later and do it, even if it is something you normally do."
         }
       ],
       "subtypes": [
@@ -19350,10 +17037,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19362,19 +17045,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19383,6 +17054,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "153",
       "multiverseid": 130816,
       "name": "Seal of Primordium",
       "number": "153",
@@ -19471,10 +17143,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19483,19 +17151,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19504,6 +17160,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "154",
       "multiverseid": 126021,
       "name": "Cautery Sliver",
       "number": "154",
@@ -19601,10 +17258,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19613,19 +17266,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19634,6 +17275,7 @@
         }
       ],
       "manaCost": "{B}{G}",
+      "mciNumber": "155",
       "multiverseid": 126012,
       "name": "Darkheart Sliver",
       "number": "155",
@@ -19647,7 +17289,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "The player who controlled the Sliver that's sacrificed gains the life, not the controller of Darkheart Sliver."
+          "text": "The player who controlled the Sliver that’s sacrificed gains the life, not the controller of Darkheart Sliver."
         },
         {
           "date": "2013-07-01",
@@ -19731,10 +17373,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19743,19 +17381,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19764,6 +17390,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "156",
       "multiverseid": 126025,
       "name": "Dormant Sliver",
       "number": "156",
@@ -19864,10 +17491,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19876,19 +17499,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19897,6 +17508,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "157",
       "multiverseid": 126011,
       "name": "Frenetic Sliver",
       "number": "157",
@@ -19995,10 +17607,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20007,19 +17615,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20028,6 +17624,7 @@
         }
       ],
       "manaCost": "{3}{U}{R}{G}",
+      "mciNumber": "158",
       "multiverseid": 124073,
       "name": "Intet, the Dreamer",
       "number": "158",
@@ -20042,11 +17639,11 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "After Intet leaves the battlefield, if a card exiled this way is still exiled, you may still look at it. You won't be able to play it, though."
+          "text": "After Intet leaves the battlefield, if a card exiled this way is still exiled, you may still look at it. You won’t be able to play it, though."
         },
         {
           "date": "2007-02-01",
-          "text": "Once you play a card this way, it leaves the Exile zone and goes to the stack. You won't be able to play it again."
+          "text": "Once you play a card this way, it leaves the Exile zone and goes to the stack. You won’t be able to play it again."
         }
       ],
       "subtypes": [
@@ -20125,10 +17722,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20137,19 +17730,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20158,6 +17739,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "159",
       "multiverseid": 126023,
       "name": "Necrotic Sliver",
       "number": "159",
@@ -20253,10 +17835,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20265,19 +17843,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20286,6 +17852,7 @@
         }
       ],
       "manaCost": "{3}{R}{W}{U}",
+      "mciNumber": "160",
       "multiverseid": 124062,
       "name": "Numot, the Devastator",
       "number": "160",
@@ -20380,10 +17947,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20392,19 +17955,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20413,6 +17964,7 @@
         }
       ],
       "manaCost": "{3}{W}{B}{R}",
+      "mciNumber": "161",
       "multiverseid": 136170,
       "name": "Oros, the Avenger",
       "number": "161",
@@ -20501,10 +18053,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20513,19 +18061,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20534,6 +18070,7 @@
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "162",
       "multiverseid": 128949,
       "name": "Radha, Heir to Keld",
       "number": "162",
@@ -20547,7 +18084,7 @@
       "rulings": [
         {
           "date": "2007-02-01",
-          "text": "Radha's triggered ability is not a mana ability (because it doesn't trigger from another mana ability). It goes on the stack and it can be countered."
+          "text": "Radha’s triggered ability is not a mana ability (because it doesn’t trigger from another mana ability). It goes on the stack and it can be countered."
         }
       ],
       "subtypes": [
@@ -20628,10 +18165,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20640,19 +18173,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20661,6 +18182,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}{W}",
+      "mciNumber": "163",
       "multiverseid": 124075,
       "name": "Teneb, the Harvester",
       "number": "163",
@@ -20755,10 +18277,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20767,19 +18285,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20788,6 +18294,7 @@
         }
       ],
       "manaCost": "{3}{G}{U}{B}",
+      "mciNumber": "164",
       "multiverseid": 124057,
       "name": "Vorosh, the Hunter",
       "number": "164",
@@ -20866,10 +18373,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20878,19 +18381,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20898,6 +18389,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "165",
       "multiverseid": 131005,
       "name": "Urborg, Tomb of Yawgmoth",
       "number": "165",
@@ -20912,7 +18404,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have \"{T}: Add {R} to your mana pool\" and no other abilities."
+          "text": "If Urborg, Tomb of Yawgmoth and either Blood Moon or Magus of the Moon are on the battlefield, all nonbasic lands will be Mountains, not Swamps. Urborg, Tomb of Yawgmoth will be a Mountain as well. It will have “{T}: Add {R} to your mana pool” and no other abilities."
         },
         {
           "date": "2014-07-18",

--- a/json/TOR.json
+++ b/json/TOR.json
@@ -23,6 +23,15 @@
     "common",
     "common"
   ],
+  "translations": {
+    "de": "Qualen",
+    "fr": "Tourment",
+    "it": "Tormento",
+    "es": "Tormento",
+    "pt": "Tormento"
+  },
+  "mkm_name": "Torment",
+  "mkm_id": 39,
   "cards": [
     {
       "artist": "rk post",
@@ -70,10 +79,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -82,23 +87,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{6}{W}",
+      "mciNumber": "1",
       "multiverseid": 32233,
       "name": "Angel of Retribution",
       "number": "1",
@@ -165,10 +159,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -177,23 +167,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "2",
       "multiverseid": 5584,
       "name": "Aven Trooper",
       "number": "2",
@@ -260,10 +239,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -272,23 +247,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 29883,
       "name": "Cleansing Meditation",
       "number": "3",
@@ -305,7 +269,7 @@
         },
         {
           "date": "2005-08-01",
-          "text": "Auras returning to the battlefield can only enchant something that was already on the battlefield. An Enchant Enchantment returning to the battlefield can't be placed on an enchantment that is also in the process of returning to the battlefield."
+          "text": "Auras returning to the battlefield can only enchant something that was already on the battlefield. An Enchant Enchantment returning to the battlefield can’t be placed on an enchantment that is also in the process of returning to the battlefield."
         }
       ],
       "text": "Destroy all enchantments.\nThreshold — If seven or more cards are in your graveyard, instead destroy all enchantments, then return all cards in your graveyard destroyed this way to the battlefield.",
@@ -359,10 +323,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -371,23 +331,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "4",
       "multiverseid": 29571,
       "name": "Equal Treatment",
       "number": "4",
@@ -448,10 +397,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -460,23 +405,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "5",
       "multiverseid": 32396,
       "name": "Floating Shield",
       "number": "5",
@@ -541,10 +475,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -553,23 +483,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "6",
       "multiverseid": 29841,
       "name": "Frantic Purification",
       "number": "6",
@@ -579,7 +498,7 @@
         "TOR"
       ],
       "rarity": "Common",
-      "text": "Destroy target enchantment.\nMadness {W} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Destroy target enchantment.\nMadness {W} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -630,10 +549,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -642,23 +557,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "7",
       "multiverseid": 29705,
       "name": "Hypochondria",
       "number": "7",
@@ -720,10 +624,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -732,23 +632,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "8",
       "multiverseid": 29912,
       "name": "Major Teroh",
       "number": "8",
@@ -818,10 +707,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -830,23 +715,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "9",
       "multiverseid": 12363,
       "name": "Militant Monk",
       "number": "9",
@@ -915,10 +789,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -927,23 +797,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "10",
       "multiverseid": 34234,
       "name": "Morningtide",
       "number": "10",
@@ -1005,10 +864,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1017,23 +872,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "11",
       "multiverseid": 30607,
       "name": "Mystic Familiar",
       "number": "11",
@@ -1100,10 +944,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1116,23 +956,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "12",
       "multiverseid": 32232,
       "name": "Pay No Heed",
       "number": "12",
@@ -1206,10 +1035,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1218,23 +1043,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "13",
       "multiverseid": 29816,
       "name": "Possessed Nomad",
       "number": "13",
@@ -1302,10 +1116,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1314,23 +1124,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "14",
       "multiverseid": 34247,
       "name": "Reborn Hero",
       "number": "14",
@@ -1344,7 +1143,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "You must already have seven or more cards in your graveyard before Reborn Hero is put into the graveyard in order for its Threshold ability to trigger; you don't include Reborn Hero itself in the count."
+          "text": "You must already have seven or more cards in your graveyard before Reborn Hero is put into the graveyard in order for its Threshold ability to trigger; you don’t include Reborn Hero itself in the count."
         }
       ],
       "subtypes": [
@@ -1403,10 +1202,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1415,23 +1210,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "15",
       "multiverseid": 26361,
       "name": "Spirit Flare",
       "number": "15",
@@ -1499,10 +1283,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1511,23 +1291,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "16",
       "multiverseid": 35082,
       "name": "Stern Judge",
       "number": "16",
@@ -1595,10 +1364,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1607,23 +1372,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "17",
       "multiverseid": 34782,
       "name": "Strength of Isolation",
       "number": "17",
@@ -1636,7 +1390,7 @@
       "subtypes": [
         "Aura"
       ],
-      "text": "Enchant creature\nEnchanted creature gets +1/+2 and has protection from black.\nMadness {W} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Enchant creature\nEnchanted creature gets +1/+2 and has protection from black.\nMadness {W} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Enchantment — Aura",
       "types": [
         "Enchantment"
@@ -1688,10 +1442,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1700,23 +1450,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "18",
       "multiverseid": 12345,
       "name": "Teroh's Faithful",
       "number": "18",
@@ -1784,10 +1523,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1796,23 +1531,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "19",
       "multiverseid": 32205,
       "name": "Teroh's Vanguard",
       "number": "19",
@@ -1879,10 +1603,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1891,23 +1611,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{W}{W}{W}",
+      "mciNumber": "20",
       "multiverseid": 8875,
       "name": "Transcendence",
       "number": "20",
@@ -1920,7 +1629,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If your life total is 20 or more and you control an effect that states \"you can't lose the game\", then an infinite loop is formed. If neither player wants to end the loop by removing one of these two cards from the battlefield, the game ends in a draw."
+          "text": "If your life total is 20 or more and you control an effect that states “you can’t lose the game\", then an infinite loop is formed. If neither player wants to end the loop by removing one of these two cards from the battlefield, the game ends in a draw."
         }
       ],
       "text": "You don't lose the game for having 0 or less life.\nWhen you have 20 or more life, you lose the game.\nWhenever you lose life, you gain 2 life for each 1 life you lost. (Damage dealt to you causes you to lose life.)",
@@ -1975,10 +1684,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1987,23 +1692,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "21",
       "multiverseid": 29698,
       "name": "Vengeful Dreams",
       "number": "21",
@@ -2064,10 +1758,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2076,23 +1766,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "22",
       "multiverseid": 34832,
       "name": "Alter Reality",
       "number": "22",
@@ -2113,7 +1792,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It can't change a word to the same word. It must be a different word."
+          "text": "It can’t change a word to the same word. It must be a different word."
         },
         {
           "date": "2004-10-04",
@@ -2184,10 +1863,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2200,23 +1875,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "23",
       "multiverseid": 34378,
       "name": "Ambassador Laquatus",
       "number": "23",
@@ -2288,10 +1952,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2300,23 +1960,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "24",
       "multiverseid": 34465,
       "name": "Aquamoeba",
       "number": "24",
@@ -2335,7 +1984,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -2396,10 +2045,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2408,23 +2053,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "25",
       "multiverseid": 32915,
       "name": "Balshan Collaborator",
       "number": "25",
@@ -2492,10 +2126,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2504,23 +2134,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{X}{U}",
+      "mciNumber": "26",
       "multiverseid": 29927,
       "name": "Breakthrough",
       "number": "26",
@@ -2583,10 +2202,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2595,23 +2210,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "27",
       "multiverseid": 29708,
       "name": "Cephalid Aristocrat",
       "number": "27",
@@ -2677,10 +2281,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2689,23 +2289,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "28",
       "multiverseid": 34776,
       "name": "Cephalid Illusionist",
       "number": "28",
@@ -2772,10 +2361,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2784,23 +2369,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "29",
       "multiverseid": 33690,
       "name": "Cephalid Sage",
       "number": "29",
@@ -2867,10 +2441,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2879,23 +2449,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "30",
       "multiverseid": 31840,
       "name": "Cephalid Snitch",
       "number": "30",
@@ -2962,10 +2521,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2974,23 +2529,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "31",
       "multiverseid": 36034,
       "name": "Cephalid Vandal",
       "number": "31",
@@ -3058,10 +2602,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3070,23 +2610,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "32",
       "multiverseid": 29720,
       "name": "Churning Eddy",
       "number": "32",
@@ -3147,10 +2676,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3159,23 +2684,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "33",
       "multiverseid": 34368,
       "name": "Circular Logic",
       "number": "33",
@@ -3187,7 +2701,7 @@
         "VMA"
       ],
       "rarity": "Uncommon",
-      "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -3238,10 +2752,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3250,23 +2760,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "34",
       "multiverseid": 34473,
       "name": "Compulsion",
       "number": "34",
@@ -3327,10 +2826,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3339,23 +2834,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "35",
       "multiverseid": 19696,
       "name": "Coral Net",
       "number": "35",
@@ -3420,10 +2904,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3432,23 +2912,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "36",
       "multiverseid": 32237,
       "name": "Deep Analysis",
       "number": "36",
@@ -3514,10 +2983,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3526,23 +2991,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "37",
       "multiverseid": 5598,
       "name": "False Memories",
       "number": "37",
@@ -3628,6 +3082,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "38",
       "multiverseid": 32235,
       "name": "Ghostly Wings",
       "number": "38",
@@ -3638,6 +3093,24 @@
         "SOI"
       ],
       "rarity": "Common",
+      "rulings": [
+        {
+          "date": "2016-04-08",
+          "text": "You control Ghostly Wings even while it enchants an opponent’s creature. Only you can activate the last ability of Ghostly Wings."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "After the last ability of Ghostly Wings resolves, it will be an Aura on the battlefield that isn’t attached to a creature and will immediately be put into its owner’s graveyard."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If Ghostly Wings leaves the battlefield before its activated ability resolves, the creature that was enchanted immediately before Ghostly Wings left is the one that will be returned to its owner’s hand, if it’s still on the battlefield."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "You can activate the last ability multiple times to discard multiple cards. Only the first ability to resolve will have any effect."
+        }
+      ],
       "subtypes": [
         "Aura"
       ],
@@ -3693,10 +3166,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3705,23 +3174,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "39",
       "multiverseid": 33627,
       "name": "Hydromorph Guardian",
       "number": "39",
@@ -3788,10 +3246,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3800,23 +3254,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "40",
       "multiverseid": 29719,
       "name": "Hydromorph Gull",
       "number": "40",
@@ -3883,10 +3326,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3895,23 +3334,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "41",
       "multiverseid": 34756,
       "name": "Liquify",
       "number": "41",
@@ -3972,10 +3400,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3984,23 +3408,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "42",
       "multiverseid": 27175,
       "name": "Llawan, Cephalid Empress",
       "number": "42",
@@ -4070,10 +3483,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4082,23 +3491,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "43",
       "multiverseid": 29721,
       "name": "Obsessive Search",
       "number": "43",
@@ -4109,7 +3507,7 @@
         "VMA"
       ],
       "rarity": "Common",
-      "text": "Draw a card.\nMadness {U} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Draw a card.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -4161,10 +3559,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4177,23 +3571,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "44",
       "multiverseid": 29824,
       "name": "Plagiarize",
       "number": "44",
@@ -4208,11 +3591,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can't modify the same event more than once. This effect will not modify the draw that it has you perform."
+          "text": "If you target yourself, this spell has no useful effect. It will not cause an infinite loop since a replacement effect can’t modify the same event more than once. This effect will not modify the draw that it has you perform."
         },
         {
           "date": "2007-07-15",
-          "text": "You draw the card from your library as normal, not from your opponent's library."
+          "text": "You draw the card from your library as normal, not from your opponent’s library."
         },
         {
           "date": "2007-07-15",
@@ -4220,7 +3603,7 @@
         },
         {
           "date": "2007-07-15",
-          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn't matter that the other player would be unable to draw."
+          "text": "If you target a player whose library is empty, any effect or turn-based action that would cause that player to draw a card will cause you to draw a card instead. It doesn’t matter that the other player would be unable to draw."
         }
       ],
       "text": "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card.",
@@ -4275,10 +3658,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4287,23 +3666,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "45",
       "multiverseid": 30658,
       "name": "Possessed Aven",
       "number": "45",
@@ -4372,10 +3740,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4384,23 +3748,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "46",
       "multiverseid": 33698,
       "name": "Retraced Image",
       "number": "46",
@@ -4462,10 +3815,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4474,23 +3823,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "47",
       "multiverseid": 29713,
       "name": "Skywing Aven",
       "number": "47",
@@ -4559,10 +3897,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4571,23 +3905,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "48",
       "multiverseid": 36415,
       "name": "Stupefying Touch",
       "number": "48",
@@ -4600,7 +3923,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder texts."
         }
       ],
       "subtypes": [
@@ -4658,10 +3981,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4670,23 +3989,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "49",
       "multiverseid": 29827,
       "name": "Turbulent Dreams",
       "number": "49",
@@ -4747,10 +4055,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4759,23 +4063,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "50",
       "multiverseid": 32225,
       "name": "Boneshard Slasher",
       "number": "50",
@@ -4842,10 +4135,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4854,23 +4143,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "51",
       "multiverseid": 30564,
       "name": "Cabal Ritual",
       "number": "51",
@@ -4933,10 +4211,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4945,23 +4219,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "52",
       "multiverseid": 32224,
       "name": "Cabal Surgeon",
       "number": "52",
@@ -5028,10 +4291,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5040,23 +4299,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "53",
       "multiverseid": 32226,
       "name": "Cabal Torturer",
       "number": "53",
@@ -5124,10 +4372,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5136,23 +4380,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "54",
       "multiverseid": 26279,
       "name": "Carrion Rats",
       "number": "54",
@@ -5219,10 +4452,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5231,23 +4460,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "55",
       "multiverseid": 26449,
       "name": "Carrion Wurm",
       "number": "55",
@@ -5314,10 +4532,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5326,23 +4540,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "56",
       "multiverseid": 32916,
       "name": "Chainer, Dementia Master",
       "number": "56",
@@ -5413,10 +4616,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5425,23 +4624,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "57",
       "multiverseid": 29603,
       "name": "Chainer's Edict",
       "number": "57",
@@ -5505,10 +4693,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5517,23 +4701,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "58",
       "multiverseid": 34225,
       "name": "Crippling Fatigue",
       "number": "58",
@@ -5594,10 +4767,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5606,23 +4775,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{B}{B}",
+      "mciNumber": "59",
       "multiverseid": 35924,
       "name": "Dawn of the Dead",
       "number": "59",
@@ -5639,7 +4797,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "If the creature leaves the battlefield, but returns to the battlefield before the triggered ability resolves, you won't exile it. This is because it is treated as a different object than the one to which the ability refers."
+          "text": "If the creature leaves the battlefield, but returns to the battlefield before the triggered ability resolves, you won’t exile it. This is because it is treated as a different object than the one to which the ability refers."
         }
       ],
       "text": "At the beginning of your upkeep, you lose 1 life.\nAt the beginning of your upkeep, you may return target creature card from your graveyard to the battlefield. That creature gains haste until end of turn. Exile it at the beginning of the next end step.",
@@ -5693,10 +4851,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5709,19 +4863,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5730,6 +4872,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "60",
       "multiverseid": 29739,
       "name": "Faceless Butcher",
       "number": "60",
@@ -5804,10 +4947,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5816,23 +4955,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "61",
       "multiverseid": 12405,
       "name": "Gloomdrifter",
       "number": "61",
@@ -5899,10 +5027,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5911,23 +5035,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "62",
       "multiverseid": 32210,
       "name": "Gravegouger",
       "number": "62",
@@ -5994,10 +5107,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6006,23 +5115,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "63",
       "multiverseid": 32222,
       "name": "Grotesque Hybrid",
       "number": "63",
@@ -6088,10 +5186,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6100,23 +5194,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{8}{B}{B}{B}",
+      "mciNumber": "64",
       "multiverseid": 31831,
       "name": "Hypnox",
       "number": "64",
@@ -6130,7 +5213,7 @@
       "rulings": [
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -6189,10 +5272,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6201,23 +5280,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "65",
       "multiverseid": 35923,
       "name": "Ichorid",
       "number": "65",
@@ -6285,10 +5353,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6297,23 +5361,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "66",
       "multiverseid": 29825,
       "name": "Insidious Dreams",
       "number": "66",
@@ -6375,10 +5428,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6387,23 +5436,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "67",
       "multiverseid": 31869,
       "name": "Laquatus's Champion",
       "number": "67",
@@ -6472,10 +5510,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6484,23 +5518,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "68",
       "multiverseid": 34467,
       "name": "Last Laugh",
       "number": "68",
@@ -6561,10 +5584,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6573,23 +5592,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "69",
       "multiverseid": 32211,
       "name": "Mesmeric Fiend",
       "number": "69",
@@ -6659,10 +5667,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6675,18 +5679,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         },
@@ -6696,6 +5688,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "70",
       "multiverseid": 26432,
       "name": "Mind Sludge",
       "number": "70",
@@ -6759,10 +5752,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6775,23 +5764,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "71",
       "multiverseid": 29960,
       "name": "Mortal Combat",
       "number": "71",
@@ -6805,11 +5783,11 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If you don't have twenty or more creature cards in your graveyard by the time your upkeep starts, the ability won't trigger that turn."
+          "text": "If you don’t have twenty or more creature cards in your graveyard by the time your upkeep starts, the ability won’t trigger that turn."
         },
         {
           "date": "2007-07-15",
-          "text": "Mortal Combat's ability has an \"intervening 'if' clause,\" so the condition is checked again when the triggered ability resolves. If you don't still have twenty creature cards in your graveyard, the ability does nothing."
+          "text": "Mortal Combat’s ability has an “intervening ‘if’ clause,” so the condition is checked again when the triggered ability resolves. If you don’t still have twenty creature cards in your graveyard, the ability does nothing."
         }
       ],
       "text": "At the beginning of your upkeep, if twenty or more creature cards are in your graveyard, you win the game.",
@@ -6863,10 +5841,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6875,23 +5849,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "72",
       "multiverseid": 36433,
       "name": "Mortiphobia",
       "number": "72",
@@ -6953,10 +5916,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6969,23 +5928,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "73",
       "multiverseid": 35194,
       "name": "Mutilate",
       "number": "73",
@@ -7002,7 +5950,7 @@
       "rulings": [
         {
           "date": "2012-07-01",
-          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won't change later in the turn, even if the number of Swamps you control changes."
+          "text": "The effect is based on the number of Swamps you control when Mutilate resolves. Only creatures on the battlefield at that time will be affected. The effect won’t change later in the turn, even if the number of Swamps you control changes."
         }
       ],
       "text": "All creatures get -1/-1 until end of turn for each Swamp you control.",
@@ -7057,10 +6005,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7073,23 +6017,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "74",
       "multiverseid": 35053,
       "name": "Nantuko Shade",
       "number": "74",
@@ -7159,10 +6092,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7171,23 +6100,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "75",
       "multiverseid": 32238,
       "name": "Organ Grinder",
       "number": "75",
@@ -7253,10 +6171,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7265,23 +6179,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "76",
       "multiverseid": 33691,
       "name": "Psychotic Haze",
       "number": "76",
@@ -7291,7 +6194,7 @@
         "TOR"
       ],
       "rarity": "Common",
-      "text": "Psychotic Haze deals 1 damage to each creature and each player.\nMadness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Psychotic Haze deals 1 damage to each creature and each player.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -7342,10 +6245,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7354,23 +6253,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "77",
       "multiverseid": 34470,
       "name": "Putrid Imp",
       "number": "77",
@@ -7439,10 +6327,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7451,23 +6335,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "78",
       "multiverseid": 31598,
       "name": "Rancid Earth",
       "number": "78",
@@ -7529,10 +6402,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7541,23 +6410,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "79",
       "multiverseid": 29908,
       "name": "Restless Dreams",
       "number": "79",
@@ -7619,10 +6477,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7635,23 +6489,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -7660,6 +6498,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "80",
       "multiverseid": 35086,
       "name": "Sengir Vampire",
       "number": "80",
@@ -7692,15 +6531,15 @@
       "rulings": [
         {
           "date": "2007-07-15",
-          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire's ability will trigger and it will get a +1/+1 counter."
+          "text": "If Sengir Vampire deals nonlethal damage to a creature and then a different effect or damage source causes that creature to be put into a graveyard later in the turn, Sengir Vampire’s ability will trigger and it will get a +1/+1 counter."
         },
         {
           "date": "2011-09-22",
-          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
+          "text": "Each time a creature is put into a graveyard from the battlefield, check whether Sengir Vampire had dealt any damage to it at any time during that turn. If so, Sengir Vampire’s ability will trigger. It doesn’t matter who controlled the creature or whose graveyard it was put into."
         },
         {
           "date": "2011-09-22",
-          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire's ability will trigger, but it will do nothing when it resolves."
+          "text": "If Sengir Vampire and a creature it dealt damage to are both put into a graveyard at the same time, Sengir Vampire’s ability will trigger, but it will do nothing when it resolves."
         }
       ],
       "subtypes": [
@@ -7758,10 +6597,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7770,23 +6605,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "81",
       "multiverseid": 23043,
       "name": "Shade's Form",
       "number": "81",
@@ -7851,10 +6675,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7863,23 +6683,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}{B}",
+      "mciNumber": "82",
       "multiverseid": 31822,
       "name": "Shambling Swarm",
       "number": "82",
@@ -7893,7 +6702,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "The -1/-1 counters you remove don't have to be the same counters put on the creature by Shambling Swarm."
+          "text": "The -1/-1 counters you remove don’t have to be the same counters put on the creature by Shambling Swarm."
         }
       ],
       "subtypes": [
@@ -7952,10 +6761,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7964,23 +6769,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "83",
       "multiverseid": 35063,
       "name": "Sickening Dreams",
       "number": "83",
@@ -8042,10 +6836,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8054,23 +6844,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "84",
       "multiverseid": 31833,
       "name": "Slithery Stalker",
       "number": "84",
@@ -8137,10 +6916,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8149,23 +6924,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "85",
       "multiverseid": 29731,
       "name": "Soul Scourge",
       "number": "85",
@@ -8233,10 +6997,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8245,23 +7005,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "86",
       "multiverseid": 34222,
       "name": "Strength of Lunacy",
       "number": "86",
@@ -8274,7 +7023,7 @@
       "subtypes": [
         "Aura"
       ],
-      "text": "Enchant creature\nEnchanted creature gets +2/+1 and has protection from white.\nMadness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Enchant creature\nEnchanted creature gets +2/+1 and has protection from white.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Enchantment — Aura",
       "types": [
         "Enchantment"
@@ -8326,10 +7075,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8338,23 +7083,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "87",
       "multiverseid": 35922,
       "name": "Unhinge",
       "number": "87",
@@ -8416,10 +7150,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8428,23 +7158,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "88",
       "multiverseid": 32133,
       "name": "Waste Away",
       "number": "88",
@@ -8506,10 +7225,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8518,23 +7233,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{B}{B}{B}",
+      "mciNumber": "89",
       "multiverseid": 34819,
       "name": "Zombie Trailblazer",
       "number": "89",
@@ -8602,10 +7306,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8614,23 +7314,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "90",
       "multiverseid": 29857,
       "name": "Accelerate",
       "number": "90",
@@ -8692,10 +7381,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8704,23 +7389,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "91",
       "multiverseid": 19553,
       "name": "Balthor the Stout",
       "number": "91",
@@ -8797,10 +7471,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8809,23 +7479,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "92",
       "multiverseid": 26726,
       "name": "Barbarian Outcast",
       "number": "92",
@@ -8894,10 +7553,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8906,23 +7561,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "93",
       "multiverseid": 34278,
       "name": "Crackling Club",
       "number": "93",
@@ -8987,10 +7631,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8999,23 +7639,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "94",
       "multiverseid": 29754,
       "name": "Crazed Firecat",
       "number": "94",
@@ -9083,10 +7712,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9095,23 +7720,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}{R}",
+      "mciNumber": "95",
       "multiverseid": 30561,
       "name": "Devastating Dreams",
       "number": "95",
@@ -9173,10 +7787,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9185,23 +7795,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "96",
       "multiverseid": 32917,
       "name": "Enslaved Dwarf",
       "number": "96",
@@ -9296,6 +7895,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "97",
       "multiverseid": 32918,
       "name": "Fiery Temper",
       "number": "97",
@@ -9308,7 +7908,45 @@
         "SOI"
       ],
       "rarity": "Common",
-      "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness {R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "rulings": [
+        {
+          "date": "2016-04-08",
+          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "Effects that cause you to pay more or less for a spell will cause you to pay that much more or less for its madness cost, too."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "When you cast a card with madness, it was still discarded. If it was discarded to pay a cost, that cost is still paid. Abilities that trigger when a card is discarded will still trigger."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If you discard a card with madness while resolving a spell or ability, it moves immediately to exile. Continue resolving that spell or ability—the card is not in your graveyard at this time. Its madness trigger will be placed onto the stack once that spell or ability has completely resolved."
+        }
+      ],
+      "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -9359,10 +7997,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9371,23 +8005,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "98",
       "multiverseid": 32921,
       "name": "Flaming Gambit",
       "number": "98",
@@ -9448,10 +8071,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9460,23 +8079,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "99",
       "multiverseid": 29863,
       "name": "Flash of Defiance",
       "number": "99",
@@ -9538,10 +8146,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9554,23 +8158,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "100",
       "multiverseid": 36111,
       "name": "Grim Lavamancer",
       "number": "100",
@@ -9587,7 +8180,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The two cards are exiled as the cost of Grim Lavamancer's ability is paid. Players can't respond to the paying of costs by trying to move those cards to another zone."
+          "text": "The two cards are exiled as the cost of Grim Lavamancer’s ability is paid. Players can’t respond to the paying of costs by trying to move those cards to another zone."
         }
       ],
       "subtypes": [
@@ -9647,10 +8240,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9659,23 +8248,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "101",
       "multiverseid": 34384,
       "name": "Hell-Bent Raider",
       "number": "101",
@@ -9742,10 +8320,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9754,23 +8328,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "102",
       "multiverseid": 32229,
       "name": "Kamahl's Sledge",
       "number": "102",
@@ -9832,10 +8395,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9844,23 +8403,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "103",
       "multiverseid": 29770,
       "name": "Longhorn Firebeast",
       "number": "103",
@@ -9929,10 +8477,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9941,23 +8485,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "104",
       "multiverseid": 29868,
       "name": "Overmaster",
       "number": "104",
@@ -10019,10 +8552,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10031,23 +8560,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "105",
       "multiverseid": 32213,
       "name": "Pardic Arsonist",
       "number": "105",
@@ -10116,10 +8634,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10128,23 +8642,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "106",
       "multiverseid": 35054,
       "name": "Pardic Collaborator",
       "number": "106",
@@ -10212,10 +8715,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10224,23 +8723,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "107",
       "multiverseid": 32240,
       "name": "Pardic Lancer",
       "number": "107",
@@ -10307,10 +8795,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10319,23 +8803,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{6}{R}{R}",
+      "mciNumber": "108",
       "multiverseid": 29799,
       "name": "Petradon",
       "number": "108",
@@ -10402,10 +8875,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10414,23 +8883,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "109",
       "multiverseid": 31805,
       "name": "Petravark",
       "number": "109",
@@ -10498,10 +8956,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10510,23 +8964,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "110",
       "multiverseid": 36432,
       "name": "Pitchstone Wall",
       "number": "110",
@@ -10593,10 +9036,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10605,23 +9044,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "111",
       "multiverseid": 32231,
       "name": "Possessed Barbarian",
       "number": "111",
@@ -10689,10 +9117,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10701,23 +9125,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "112",
       "multiverseid": 34390,
       "name": "Pyromania",
       "number": "112",
@@ -10778,10 +9191,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10790,23 +9199,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "113",
       "multiverseid": 34250,
       "name": "Radiate",
       "number": "113",
@@ -10868,10 +9266,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10880,23 +9274,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}{R}",
+      "mciNumber": "114",
       "multiverseid": 34382,
       "name": "Skullscorch",
       "number": "114",
@@ -10957,10 +9340,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10969,23 +9348,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "115",
       "multiverseid": 35165,
       "name": "Sonic Seizure",
       "number": "115",
@@ -11046,10 +9414,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11058,23 +9422,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "116",
       "multiverseid": 32236,
       "name": "Temporary Insanity",
       "number": "116",
@@ -11136,10 +9489,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11148,23 +9497,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}{R}{R}",
+      "mciNumber": "117",
       "multiverseid": 34253,
       "name": "Violent Eruption",
       "number": "117",
@@ -11177,10 +9515,10 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can't choose zero targets. You must choose at least one target."
+          "text": "You can’t choose zero targets. You must choose at least one target."
         }
       ],
-      "text": "Violent Eruption deals 4 damage divided as you choose among any number of target creatures and/or players.\nMadness {1}{R}{R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Violent Eruption deals 4 damage divided as you choose among any number of target creatures and/or players.\nMadness {1}{R}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -11231,10 +9569,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11243,23 +9577,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "118",
       "multiverseid": 29873,
       "name": "Acorn Harvest",
       "number": "118",
@@ -11321,10 +9644,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11333,23 +9652,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "119",
       "multiverseid": 33687,
       "name": "Anurid Scavenger",
       "number": "119",
@@ -11417,10 +9725,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11429,23 +9733,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "120",
       "multiverseid": 12623,
       "name": "Arrogant Wurm",
       "number": "120",
@@ -11461,7 +9754,7 @@
       "subtypes": [
         "Wurm"
       ],
-      "text": "Trample\nMadness {2}{G} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Trample\nMadness {2}{G} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "4",
       "type": "Creature — Wurm",
       "types": [
@@ -11513,10 +9806,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11525,23 +9814,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "121",
       "multiverseid": 35072,
       "name": "Basking Rootwalla",
       "number": "121",
@@ -11559,13 +9837,13 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
+          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
         }
       ],
       "subtypes": [
         "Lizard"
       ],
-      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "1",
       "type": "Creature — Lizard",
       "types": [
@@ -11617,10 +9895,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11629,23 +9903,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "122",
       "multiverseid": 32218,
       "name": "Centaur Chieftain",
       "number": "122",
@@ -11712,10 +9975,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11724,23 +9983,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "123",
       "multiverseid": 29800,
       "name": "Centaur Veteran",
       "number": "123",
@@ -11807,10 +10055,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11819,23 +10063,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "124",
       "multiverseid": 26404,
       "name": "Dwell on the Past",
       "number": "124",
@@ -11896,10 +10129,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11908,23 +10137,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "125",
       "multiverseid": 15229,
       "name": "Far Wanderings",
       "number": "125",
@@ -11985,10 +10203,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11997,23 +10211,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "126",
       "multiverseid": 32221,
       "name": "Gurzigost",
       "number": "126",
@@ -12031,7 +10234,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren't blocked means the damage is assigned to the planeswalker, not to the defending player."
+          "text": "If this creature is attacking a planeswalker, assigning its damage as though it weren’t blocked means the damage is assigned to the planeswalker, not to the defending player."
         }
       ],
       "subtypes": [
@@ -12090,10 +10293,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12102,23 +10301,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "127",
       "multiverseid": 29886,
       "name": "Insist",
       "number": "127",
@@ -12180,10 +10368,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12192,23 +10376,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "128",
       "multiverseid": 29907,
       "name": "Invigorating Falls",
       "number": "128",
@@ -12270,10 +10443,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12282,23 +10451,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "129",
       "multiverseid": 29715,
       "name": "Krosan Constrictor",
       "number": "129",
@@ -12364,10 +10522,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12376,23 +10530,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "130",
       "multiverseid": 29872,
       "name": "Krosan Restorer",
       "number": "130",
@@ -12459,10 +10602,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12471,23 +10610,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "131",
       "multiverseid": 32243,
       "name": "Nantuko Blightcutter",
       "number": "131",
@@ -12554,10 +10682,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12566,23 +10690,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "132",
       "multiverseid": 31851,
       "name": "Nantuko Calmer",
       "number": "132",
@@ -12649,10 +10762,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12661,23 +10770,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "133",
       "multiverseid": 34229,
       "name": "Nantuko Cultivator",
       "number": "133",
@@ -12744,10 +10842,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12756,23 +10850,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "134",
       "multiverseid": 5663,
       "name": "Narcissism",
       "number": "134",
@@ -12834,10 +10917,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12846,23 +10925,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{G}{G}",
+      "mciNumber": "135",
       "multiverseid": 32208,
       "name": "Nostalgic Dreams",
       "number": "135",
@@ -12924,10 +10992,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12936,23 +11000,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "136",
       "multiverseid": 29992,
       "name": "Parallel Evolution",
       "number": "136",
@@ -13014,10 +11067,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13026,23 +11075,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "137",
       "multiverseid": 29787,
       "name": "Possessed Centaur",
       "number": "137",
@@ -13109,10 +11147,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13121,23 +11155,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "138",
       "multiverseid": 32244,
       "name": "Seton's Scout",
       "number": "138",
@@ -13203,10 +11226,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13215,22 +11234,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
+      "mciNumber": "139",
       "multiverseid": 29896,
       "name": "Cabal Coffers",
       "number": "139",
@@ -13290,10 +11298,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13302,22 +11306,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
+      "mciNumber": "140",
       "multiverseid": 31757,
       "name": "Tainted Field",
       "number": "140",
@@ -13377,10 +11370,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13389,22 +11378,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
+      "mciNumber": "141",
       "multiverseid": 31758,
       "name": "Tainted Isle",
       "number": "141",
@@ -13463,10 +11441,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13475,22 +11449,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
+      "mciNumber": "142",
       "multiverseid": 31759,
       "name": "Tainted Peak",
       "number": "142",
@@ -13548,10 +11511,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13560,22 +11519,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
+      "mciNumber": "143",
       "multiverseid": 31760,
       "name": "Tainted Wood",
       "number": "143",

--- a/json/TSB.json
+++ b/json/TSB.json
@@ -6,6 +6,35 @@
   "border": "black",
   "type": "expansion",
   "block": "Time Spiral",
+  "booster": [
+    "rare",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "common",
+    "common",
+    "common",
+    "common",
+    "common",
+    "common",
+    "common",
+    "common",
+    "common",
+    "common",
+    "timeshifted purple"
+  ],
+  "translations": {
+    "de": "Zeitspirale",
+    "fr": "Spirale Temporelle",
+    "it": "Spirale Temporale",
+    "es": "Espiral del Tiempo",
+    "pt": "Time Spiral",
+    "jp": "時のらせん",
+    "cn": "Time Spiral",
+    "ru": "Спираль времени"
+  },
+  "mkm_name": "Time Spiral",
+  "mkm_id": 56,
   "cards": [
     {
       "artist": "Ron Spears",
@@ -68,10 +97,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -84,19 +109,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -105,6 +118,7 @@
         }
       ],
       "manaCost": "{5}{W}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 106645,
       "name": "Akroma, Angel of Wrath",
       "number": "1",
@@ -194,23 +208,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -222,15 +224,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "2",
       "multiverseid": 106665,
       "name": "Auratog",
       "number": "2",
@@ -313,10 +312,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -329,19 +324,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -350,6 +333,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 106639,
       "name": "Celestial Dawn",
       "number": "3",
@@ -364,7 +348,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn's effect."
+          "text": "The effect to turn all your non-land cards (including artifacts) white is the effect of a static ability. Thus, a color change on a permanent prior to Celestial Dawn entering the battlefield will be overridden by Celestial Dawn’s effect."
         },
         {
           "date": "2004-10-04",
@@ -388,11 +372,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mana produced by spells you control and nonland permanents you control isn't affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
+          "text": "Mana produced by spells you control and nonland permanents you control isn’t affected by Celestial Dawn. Llanowar Elves will produce {G}, for example. However, any colored mana may be spent only on the colorless part of costs."
         },
         {
           "date": "2006-09-25",
-          "text": "Land cards you own that aren't on the battlefield aren't changed to Plains."
+          "text": "Land cards you own that aren’t on the battlefield aren’t changed to Plains."
         },
         {
           "date": "2006-09-25",
@@ -400,15 +384,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "\"Enters the battlefield\" triggered abilities of lands you play won't trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won't return a land to your hand."
+          "text": "“Enters the battlefield” triggered abilities of lands you play won’t trigger since the lands will enter the battlefield as Plains. Effects that modify how those lands enter the battlefield, however, will still work. For example, if you play a Dimir Aqueduct, it will enter the battlefield tapped as a Plains, but you won’t return a land to your hand."
         },
         {
           "date": "2006-09-25",
-          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word \"Plains\" to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
+          "text": "If you use a text-changing effect such as Mind Bend on Celestial Dawn to change the word “Plains” to a different land type, your lands are all of that new land type, and they will produce mana of the appropriate color for that type."
         },
         {
           "date": "2006-09-25",
-          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent's color will revert to the colors in its mana cost."
+          "text": "If a permanent enters the battlefield while Celestial Dawn is on the battlefield, and then Celestial Dawn leaves the battlefield, the permanent’s color will revert to the colors in its mana cost."
         }
       ],
       "text": "Lands you control are Plains.\nNonland cards you own that aren't on the battlefield, spells you control, and nonland permanents you control are white.\nYou may spend white mana as though it were mana of any color. You may spend other mana only as though it were colorless mana.",
@@ -478,10 +462,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -490,19 +470,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -511,6 +479,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "4",
       "multiverseid": 108801,
       "name": "Consecrate Land",
       "number": "4",
@@ -532,11 +501,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Consecrate Land enters the battlefield attached to a land that's enchanted by other Auras, those Auras are put into their owners' graveyards."
+          "text": "If Consecrate Land enters the battlefield attached to a land that’s enchanted by other Auras, those Auras are put into their owners’ graveyards."
         },
         {
           "date": "2013-07-01",
-          "text": "A permanent with indestructible can't be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
+          "text": "A permanent with indestructible can’t be destroyed, but it can still be sacrificed, exiled, put into a graveyard, and so on."
         }
       ],
       "subtypes": [
@@ -609,10 +578,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -625,19 +590,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -646,6 +599,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "5",
       "multiverseid": 108803,
       "name": "Defiant Vanguard",
       "number": "5",
@@ -735,10 +689,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -759,23 +709,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
           "legality": "Legal"
         },
         {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -788,6 +726,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "6",
       "multiverseid": 107302,
       "name": "Disenchant",
       "number": "6",
@@ -895,10 +834,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -911,19 +846,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -932,6 +855,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "7",
       "multiverseid": 108842,
       "name": "Enduring Renewal",
       "number": "7",
@@ -945,7 +869,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Enduring Renewal only affects creature cards that are \"drawn\". It doesn't affect cards that are put into your hand from your library, or from anywhere else."
+          "text": "Enduring Renewal only affects creature cards that are “drawn\". It doesn’t affect cards that are put into your hand from your library, or from anywhere else."
         },
         {
           "date": "2004-10-04",
@@ -965,11 +889,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If, after the last ability triggers, the creature card is removed from your graveyard in response, it won't be returned to your hand."
+          "text": "If, after the last ability triggers, the creature card is removed from your graveyard in response, it won’t be returned to your hand."
         },
         {
           "date": "2008-04-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "text": "Play with your hand revealed.\nIf you would draw a card, reveal the top card of your library instead. If it's a creature card, put it into your graveyard. Otherwise, draw a card.\nWhenever a creature is put into your graveyard from the battlefield, return it to your hand.",
@@ -1040,10 +964,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1056,19 +976,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1077,6 +985,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "8",
       "multiverseid": 106647,
       "name": "Essence Sliver",
       "number": "8",
@@ -1173,10 +1082,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1189,19 +1094,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1210,6 +1103,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "9",
       "multiverseid": 108879,
       "name": "Honorable Passage",
       "number": "9",
@@ -1287,10 +1181,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1299,19 +1189,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1320,6 +1198,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "10",
       "multiverseid": 107283,
       "name": "Icatian Javelineers",
       "number": "10",
@@ -1408,10 +1287,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1420,19 +1295,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1441,6 +1304,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 108849,
       "name": "Moorish Cavalry",
       "number": "11",
@@ -1524,10 +1388,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1536,19 +1396,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1557,6 +1405,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "12",
       "multiverseid": 108885,
       "name": "Resurrection",
       "number": "12",
@@ -1641,10 +1490,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1657,19 +1502,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1678,6 +1511,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "13",
       "multiverseid": 106625,
       "name": "Sacred Mesa",
       "number": "13",
@@ -1764,23 +1598,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -1792,15 +1614,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "14",
       "multiverseid": 108856,
       "name": "Soltari Priest",
       "number": "14",
@@ -1888,10 +1707,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1900,19 +1715,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1921,6 +1724,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "15",
       "multiverseid": 108908,
       "name": "Squire",
       "number": "15",
@@ -2003,10 +1807,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2019,19 +1819,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2040,6 +1828,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "16",
       "multiverseid": 106628,
       "name": "Valor",
       "number": "16",
@@ -2122,10 +1911,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2134,19 +1919,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2155,6 +1928,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "17",
       "multiverseid": 108794,
       "name": "Witch Hunter",
       "number": "17",
@@ -2240,10 +2014,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2256,19 +2026,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2277,6 +2035,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "18",
       "multiverseid": 108868,
       "name": "Zhalfirin Commander",
       "number": "18",
@@ -2362,10 +2121,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2374,19 +2129,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2395,6 +2138,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "19",
       "multiverseid": 106631,
       "name": "Dandân",
       "number": "19",
@@ -2480,10 +2224,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2492,19 +2232,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2513,6 +2241,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "20",
       "multiverseid": 107291,
       "name": "Flying Men",
       "number": "20",
@@ -2596,10 +2325,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2608,19 +2333,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2629,6 +2342,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "21",
       "multiverseid": 107294,
       "name": "Ghost Ship",
       "number": "21",
@@ -2712,10 +2426,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2724,19 +2434,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2745,6 +2443,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "22",
       "multiverseid": 108816,
       "name": "Giant Oyster",
       "number": "22",
@@ -2767,11 +2466,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Activating the ability creates a continuous effect that works only as long as Giant Oyster remains tapped, a repeating delayed triggered ability that's in effect only as long as Giant Oyster remains tapped, and a delayed triggered ability that triggers when Giant Oyster untaps or when it leaves the battlefield."
+          "text": "Activating the ability creates a continuous effect that works only as long as Giant Oyster remains tapped, a repeating delayed triggered ability that’s in effect only as long as Giant Oyster remains tapped, and a delayed triggered ability that triggers when Giant Oyster untaps or when it leaves the battlefield."
         },
         {
           "date": "2006-09-25",
-          "text": "Giant Oyster's ability can be activated during your upkeep, and the creature will get a -1/-1 counter during the draw step that follows it."
+          "text": "Giant Oyster’s ability can be activated during your upkeep, and the creature will get a -1/-1 counter during the draw step that follows it."
         }
       ],
       "subtypes": [
@@ -2845,10 +2544,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2857,19 +2552,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2878,6 +2561,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}{U}{U}",
+      "mciNumber": "23",
       "multiverseid": 108920,
       "name": "Leviathan",
       "number": "23",
@@ -2895,7 +2579,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You don't have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
+          "text": "You don’t have to pay the untap cost if it is untapped outside the upkeep phase or is untapped by an effect."
         }
       ],
       "subtypes": [
@@ -2970,10 +2654,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2982,19 +2662,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3003,6 +2671,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "24",
       "multiverseid": 106642,
       "name": "Lord of Atlantis",
       "number": "24",
@@ -3095,10 +2764,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3107,19 +2772,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3128,6 +2781,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "25",
       "multiverseid": 108821,
       "name": "Merfolk Assassin",
       "number": "25",
@@ -3218,10 +2872,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3234,19 +2884,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3255,6 +2893,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "26",
       "multiverseid": 111062,
       "name": "Mistform Ultimus",
       "number": "26",
@@ -3269,7 +2908,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The type \"Illusion\" is printed on the card's type line purely for flavor. The Ultimus has every other creature type as well."
+          "text": "The type “Illusion” is printed on the card’s type line purely for flavor. The Ultimus has every other creature type as well."
         },
         {
           "date": "2006-09-25",
@@ -3277,7 +2916,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Mistform Ultimus has all creature types even if an effect removes its ability. Type-changing static abilities will apply in layer 4 before effects such as Sudden Spoiling's remove them in layer 6."
+          "text": "Mistform Ultimus has all creature types even if an effect removes its ability. Type-changing static abilities will apply in layer 4 before effects such as Sudden Spoiling’s remove them in layer 6."
         }
       ],
       "subtypes": [
@@ -3354,10 +2993,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3370,19 +3005,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3391,6 +3014,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "27",
       "multiverseid": 108863,
       "name": "Ovinomancer",
       "number": "27",
@@ -3481,10 +3105,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3493,19 +3113,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3514,6 +3122,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "28",
       "multiverseid": 108925,
       "name": "Pirate Ship",
       "number": "28",
@@ -3605,10 +3214,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3617,19 +3222,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3638,6 +3231,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "29",
       "multiverseid": 108906,
       "name": "Prodigal Sorcerer",
       "number": "29",
@@ -3734,10 +3328,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3746,19 +3336,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3767,6 +3345,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "30",
       "multiverseid": 108812,
       "name": "Psionic Blast",
       "number": "30",
@@ -3849,10 +3428,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3861,19 +3436,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3882,6 +3445,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "31",
       "multiverseid": 108935,
       "name": "Sindbad",
       "number": "31",
@@ -3897,7 +3461,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If the draw is replaced by another effect, none of the rest of Sindbad's ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
+          "text": "If the draw is replaced by another effect, none of the rest of Sindbad’s ability applies, even if the draw is replaced by another draw (such as with Enduring Renewal)."
         },
         {
           "date": "2006-09-25",
@@ -3976,10 +3540,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -3992,19 +3552,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4013,6 +3561,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "32",
       "multiverseid": 106637,
       "name": "Stormscape Familiar",
       "number": "32",
@@ -4031,7 +3580,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell’s cost."
         },
         {
           "date": "2004-10-04",
@@ -4051,7 +3600,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -4125,10 +3674,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4137,19 +3682,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4158,6 +3691,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "33",
       "multiverseid": 108827,
       "name": "Unstable Mutation",
       "number": "33",
@@ -4247,10 +3781,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4263,19 +3793,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4284,6 +3802,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "34",
       "multiverseid": 108811,
       "name": "Voidmage Prodigy",
       "number": "34",
@@ -4369,23 +3888,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -4397,15 +3904,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "35",
       "multiverseid": 106651,
       "name": "Whispers of the Muse",
       "number": "35",
@@ -4484,10 +3988,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4500,19 +4000,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4521,6 +4009,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "36",
       "multiverseid": 108861,
       "name": "Willbender",
       "number": "36",
@@ -4619,10 +4108,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4635,19 +4120,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4656,6 +4129,7 @@
         }
       ],
       "manaCost": "{6}{B}{B}",
+      "mciNumber": "37",
       "multiverseid": 108929,
       "name": "Avatar of Woe",
       "number": "37",
@@ -4748,10 +4222,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4760,19 +4230,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4781,6 +4239,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "38",
       "multiverseid": 108818,
       "name": "Bad Moon",
       "number": "38",
@@ -4868,10 +4327,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4884,19 +4339,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4926,11 +4369,11 @@
         },
         {
           "date": "2005-08-01",
-          "text": "\"Legend\" is no longer a creature type, and may not be chosen."
+          "text": "“Legend” is no longer a creature type, and may not be chosen."
         },
         {
           "date": "2005-08-01",
-          "text": "If you choose Wall, then your creatures can still attack because creature types don't confer abilities such as defender (any more than, say, choosing creature type Bird would confer flying)."
+          "text": "If you choose Wall, then your creatures can still attack because creature types don’t confer abilities such as defender (any more than, say, choosing creature type Bird would confer flying)."
         },
         {
           "date": "2013-09-20",
@@ -5005,10 +4448,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5017,19 +4456,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5038,6 +4465,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "40",
       "multiverseid": 108919,
       "name": "Darkness",
       "number": "40",
@@ -5116,23 +4544,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -5144,15 +4560,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "41",
       "multiverseid": 107288,
       "name": "Dauthi Slayer",
       "number": "41",
@@ -5239,10 +4652,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5251,19 +4660,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5272,6 +4669,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "42",
       "multiverseid": 107278,
       "name": "Evil Eye of Orms-by-Gore",
       "number": "42",
@@ -5356,10 +4754,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5372,19 +4766,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5393,6 +4775,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "43",
       "multiverseid": 108840,
       "name": "Faceless Butcher",
       "number": "43",
@@ -5483,10 +4866,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5499,19 +4878,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5520,6 +4887,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "44",
       "multiverseid": 108895,
       "name": "Funeral Charm",
       "number": "44",
@@ -5598,10 +4966,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5610,19 +4974,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5631,6 +4983,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "45",
       "multiverseid": 106638,
       "name": "Sengir Autocrat",
       "number": "45",
@@ -5724,10 +5077,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5740,19 +5089,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5761,6 +5098,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "46",
       "multiverseid": 108864,
       "name": "Shadow Guildmage",
       "number": "46",
@@ -5844,10 +5182,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5860,19 +5194,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5881,6 +5203,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "47",
       "multiverseid": 106644,
       "name": "Soul Collector",
       "number": "47",
@@ -5971,10 +5294,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5987,19 +5306,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6008,6 +5315,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "48",
       "multiverseid": 108923,
       "name": "Stupor",
       "number": "48",
@@ -6087,10 +5395,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -6103,19 +5407,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6124,6 +5416,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "49",
       "multiverseid": 106656,
       "name": "Swamp Mosquito",
       "number": "49",
@@ -6142,7 +5435,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6216,10 +5509,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6232,19 +5521,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6253,6 +5530,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "50",
       "multiverseid": 108848,
       "name": "Twisted Abomination",
       "number": "50",
@@ -6272,7 +5550,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Swampcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Swampcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Swamp card. After you find a Swamp card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -6360,10 +5638,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6372,19 +5646,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6393,6 +5655,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}{B}",
+      "mciNumber": "51",
       "multiverseid": 108805,
       "name": "Uncle Istvan",
       "number": "51",
@@ -6483,10 +5746,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6499,19 +5758,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6520,6 +5767,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "52",
       "multiverseid": 108869,
       "name": "Undead Warchief",
       "number": "52",
@@ -6604,10 +5852,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6620,19 +5864,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6641,6 +5873,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "53",
       "multiverseid": 108791,
       "name": "Undertaker",
       "number": "53",
@@ -6725,10 +5958,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6741,19 +5970,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6762,6 +5979,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "54",
       "multiverseid": 108890,
       "name": "Withered Wretch",
       "number": "54",
@@ -6847,10 +6065,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6859,19 +6073,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6884,6 +6086,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "55",
       "multiverseid": 108835,
       "name": "Avalanche Riders",
       "number": "55",
@@ -6969,10 +6172,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6985,19 +6184,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7006,6 +6193,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "56",
       "multiverseid": 107299,
       "name": "Browbeat",
       "number": "56",
@@ -7088,10 +6276,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -7104,19 +6288,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7125,6 +6297,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "57",
       "multiverseid": 108917,
       "name": "Desolation Giant",
       "number": "57",
@@ -7208,10 +6381,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7220,19 +6389,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7241,6 +6398,7 @@
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "58",
       "multiverseid": 106636,
       "name": "Disintegrate",
       "number": "58",
@@ -7263,7 +6421,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The \"can't regenerate\" is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
+          "text": "The “can’t regenerate” is an effect of Disintegrate and not an effect of the damage. It works even if the damage is prevented or redirected. If redirected, the damage does not take this effect with it."
         },
         {
           "date": "2004-10-04",
@@ -7337,10 +6495,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7349,19 +6503,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7370,6 +6512,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "59",
       "multiverseid": 108810,
       "name": "Dragon Whelp",
       "number": "59",
@@ -7395,11 +6538,11 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The first three times Dragon Whelp's ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp's ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
+          "text": "The first three times Dragon Whelp’s ability is activated in a turn will do nothing other than give it +1/+0 until end of turn. Any subsequent activations will also cause its delayed triggered ability to trigger. That means if you activate Dragon Whelp’s ability five times, for example, two different delayed triggered abilities will trigger at the beginning of the next end step and cause you to sacrifice Dragon Whelp."
         },
         {
           "date": "2009-10-01",
-          "text": "If the fourth (or more) time Dragon Whelp's ability is activated during the same turn happens to be during that turn's end step, the delayed triggered ability won't trigger until the beginning of the next turn's end step. You'll have to sacrifice Dragon Whelp at that time."
+          "text": "If the fourth (or more) time Dragon Whelp’s ability is activated during the same turn happens to be during that turn’s end step, the delayed triggered ability won’t trigger until the beginning of the next turn’s end step. You’ll have to sacrifice Dragon Whelp at that time."
         }
       ],
       "subtypes": [
@@ -7473,10 +6616,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7489,19 +6628,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7510,6 +6637,7 @@
         }
       ],
       "manaCost": "{8}{R}",
+      "mciNumber": "60",
       "multiverseid": 108843,
       "name": "Dragonstorm",
       "number": "60",
@@ -7525,15 +6653,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -7608,10 +6736,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7620,19 +6744,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7641,6 +6753,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "61",
       "multiverseid": 108922,
       "name": "Eron the Relentless",
       "number": "61",
@@ -7756,6 +6869,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "62",
       "multiverseid": 108880,
       "name": "Fiery Temper",
       "number": "62",
@@ -7768,7 +6882,45 @@
         "SOI"
       ],
       "rarity": "Special",
-      "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness {R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "rulings": [
+        {
+          "date": "2016-04-08",
+          "text": "Cards are discarded in a Magic game only from a player’s hand. Effects that put cards from a player’s library into that player’s graveyard do not cause those cards to be discarded."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "A spell cast for its madness cost is put onto the stack like any other spell. It can be countered, copied, and so on. As it resolves, it’s put onto the battlefield if it’s a permanent card or into its owner’s graveyard if it’s an instant or sorcery card."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "Casting a spell for its madness cost doesn’t change its mana cost or its converted mana cost. You just pay the madness cost instead."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "Effects that cause you to pay more or less for a spell will cause you to pay that much more or less for its madness cost, too."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "Madness works independently of why you’re discarding the card. You could discard it to pay a cost, because a spell or ability tells you to, or even because you have too many cards in your hand at the end of your turn. You can’t discard a card with madness just because you want to, though."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "When you cast a card with madness, it was still discarded. If it was discarded to pay a cost, that cost is still paid. Abilities that trigger when a card is discarded will still trigger."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If you choose not to cast a card with madness when the madness triggered ability resolves, it’s put into your graveyard. You don’t get another chance to cast it later."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If you discard a card with madness to pay the cost of a spell or activated ability, that card’s madness trigger (and the spell that card becomes, if you choose to cast it) will resolve before the spell or ability the discard paid for."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "If you discard a card with madness while resolving a spell or ability, it moves immediately to exile. Continue resolving that spell or ability—the card is not in your graveyard at this time. Its madness trigger will be placed onto the stack once that spell or ability has completely resolved."
+        }
+      ],
+      "text": "Fiery Temper deals 3 damage to target creature or player.\nMadness {R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "timeshifted": true,
       "type": "Instant",
       "types": [
@@ -7835,10 +6987,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7851,19 +6999,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7872,6 +7008,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "63",
       "multiverseid": 108877,
       "name": "Fire Whip",
       "number": "63",
@@ -7885,7 +7022,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Remember that you tap the creature as part of the cost of activating Fire Whip's granted ability. So, if you have two Fire Whips on a creature activating the first one will tap the creature, so you can't use the second one or any other ability which requires tapping the creature until you find a way to untap it."
+          "text": "Remember that you tap the creature as part of the cost of activating Fire Whip’s granted ability. So, if you have two Fire Whips on a creature activating the first one will tap the creature, so you can’t use the second one or any other ability which requires tapping the creature until you find a way to untap it."
         },
         {
           "date": "2004-10-04",
@@ -7963,10 +7100,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -7979,19 +7112,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8000,6 +7121,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "64",
       "multiverseid": 107280,
       "name": "Goblin Snowman",
       "number": "64",
@@ -8084,10 +7206,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8096,19 +7214,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8117,6 +7223,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "65",
       "multiverseid": 106664,
       "name": "Kobold Taskmaster",
       "number": "65",
@@ -8201,10 +7308,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -8217,19 +7320,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8238,6 +7329,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "66",
       "multiverseid": 108833,
       "name": "Orcish Librarian",
       "number": "66",
@@ -8327,10 +7419,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8339,19 +7427,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8360,6 +7436,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "67",
       "multiverseid": 106646,
       "name": "Orgg",
       "number": "67",
@@ -8450,23 +7527,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -8478,15 +7543,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "68",
       "multiverseid": 108862,
       "name": "Pandemonium",
       "number": "68",
@@ -8501,11 +7563,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The triggered ability does not check the creature's power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a \"enters the battlefield\" ability, the order of resolution of the triggered abilities does not matter."
+          "text": "The triggered ability does not check the creature’s power until the ability resolves. If the creature is not on the battlefield when the ability resolves, it does damage equal to the power of the creature right before it left the battlefield. This means that if a creature enters the battlefield which can destroy itself as a “enters the battlefield” ability, the order of resolution of the triggered abilities does not matter."
         },
         {
           "date": "2006-09-25",
-          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B's control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
+          "text": "If player A controls Pandemonium when a creature enters the battlefield under player B’s control, player A controls the triggered ability even though player B chooses the target and chooses whether to have the creature deal damage, which could be important if multiple abilities controlled by multiple players trigger."
         }
       ],
       "text": "Whenever a creature enters the battlefield, that creature's controller may have it deal damage equal to its power to target creature or player of his or her choice.",
@@ -8576,10 +7638,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8592,19 +7650,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8613,6 +7659,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "69",
       "multiverseid": 108883,
       "name": "Suq'Ata Lancer",
       "number": "69",
@@ -8697,10 +7744,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -8713,19 +7756,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8734,6 +7765,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "70",
       "multiverseid": 108916,
       "name": "Tribal Flames",
       "number": "70",
@@ -8758,7 +7790,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control -- they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control -- they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Tribal Flames deals X damage to target creature or player, where X is the number of basic land types among lands you control.",
@@ -8829,10 +7861,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8841,19 +7869,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8862,6 +7878,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "71",
       "multiverseid": 108806,
       "name": "Uthden Troll",
       "number": "71",
@@ -8953,10 +7970,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8969,19 +7982,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8990,6 +7991,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "72",
       "multiverseid": 108813,
       "name": "Wildfire Emissary",
       "number": "72",
@@ -9073,10 +8075,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9085,19 +8083,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9106,6 +8092,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "73",
       "multiverseid": 108886,
       "name": "Avoid Fate",
       "number": "73",
@@ -9119,7 +8106,7 @@
       "rulings": [
         {
           "date": "2011-01-22",
-          "text": "Avoid Fate must target an instant spell or an Aura spell as it's cast, and it must be targeting an instant or an Aura spell at the time it resolves. It will still resolve if it starts out targeting a spell of one type but the target changes to a spell of the other type (thanks to Shunt, for instance) before it resolves."
+          "text": "Avoid Fate must target an instant spell or an Aura spell as it’s cast, and it must be targeting an instant or an Aura spell at the time it resolves. It will still resolve if it starts out targeting a spell of one type but the target changes to a spell of the other type (thanks to Shunt, for instance) before it resolves."
         }
       ],
       "text": "Counter target instant or Aura spell that targets a permanent you control.",
@@ -9189,10 +8176,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9205,19 +8188,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9226,6 +8197,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "74",
       "multiverseid": 109672,
       "name": "Call of the Herd",
       "number": "74",
@@ -9304,10 +8276,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9316,19 +8284,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9337,6 +8293,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "75",
       "multiverseid": 108912,
       "name": "Cockatrice",
       "number": "75",
@@ -9433,10 +8390,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9445,19 +8398,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9466,6 +8407,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}{G}{G}",
+      "mciNumber": "76",
       "multiverseid": 109748,
       "name": "Craw Giant",
       "number": "76",
@@ -9550,10 +8492,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9566,19 +8504,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9587,6 +8513,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "77",
       "multiverseid": 108789,
       "name": "Gaea's Blessing",
       "number": "77",
@@ -9601,19 +8528,19 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It targets the player and each of the cards. Thus, it is only a \"spell with one target\" if you choose to target zero cards."
+          "text": "It targets the player and each of the cards. Thus, it is only a “spell with one target” if you choose to target zero cards."
         },
         {
           "date": "2004-10-04",
-          "text": "Does not trigger the \"if moved to the graveyard\" ability if this card is discarded from your hand."
+          "text": "Does not trigger the “if moved to the graveyard” ability if this card is discarded from your hand."
         },
         {
           "date": "2004-10-04",
-          "text": "When cast as a spell, you can't choose this card as one of the targets. This is because you choose the targets when casting this spell, and this spell does not go to the graveyard until after it resolves."
+          "text": "When cast as a spell, you can’t choose this card as one of the targets. This is because you choose the targets when casting this spell, and this spell does not go to the graveyard until after it resolves."
         },
         {
           "date": "2008-04-01",
-          "text": "You must target a player. You may target zero, one, two, or three cards in that player's graveyard."
+          "text": "You must target a player. You may target zero, one, two, or three cards in that player’s graveyard."
         }
       ],
       "text": "Target player shuffles up to three target cards from his or her graveyard into his or her library.\nDraw a card.\nWhen Gaea's Blessing is put into your graveyard from your library, shuffle your graveyard into your library.",
@@ -9683,10 +8610,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9695,19 +8618,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9716,6 +8627,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}{G}",
+      "mciNumber": "78",
       "multiverseid": 109744,
       "name": "Gaea's Liege",
       "number": "78",
@@ -9736,11 +8648,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "When being declared as an attacker, use the \"not attacking\" power and toughness. It only changes after declaration is complete."
+          "text": "When being declared as an attacker, use the “not attacking” power and toughness. It only changes after declaration is complete."
         },
         {
           "date": "2006-09-25",
-          "text": "The activated ability doesn't affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability \"{T}: Add {G} to your mana pool.\""
+          "text": "The activated ability doesn’t affect whether the land is basic or not. It overwrites any other land types. Being a Forest gives the affected land the ability “{T}: Add {G} to your mana pool.”"
         },
         {
           "date": "2006-10-15",
@@ -9819,10 +8731,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -9835,19 +8743,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9856,6 +8752,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "79",
       "multiverseid": 107296,
       "name": "Hail Storm",
       "number": "79",
@@ -9933,10 +8830,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9945,19 +8838,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9970,6 +8851,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "80",
       "multiverseid": 107282,
       "name": "Hunting Moa",
       "number": "80",
@@ -10061,10 +8943,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10077,19 +8955,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10098,6 +8964,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "81",
       "multiverseid": 108786,
       "name": "Jolrael, Empress of Beasts",
       "number": "81",
@@ -10124,7 +8991,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -10202,10 +9069,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10218,19 +9081,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10239,6 +9090,7 @@
         }
       ],
       "manaCost": "{7}{G}{G}{G}",
+      "mciNumber": "82",
       "multiverseid": 109684,
       "name": "Krosan Cloudscraper",
       "number": "82",
@@ -10323,23 +9175,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -10351,15 +9191,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "83",
       "multiverseid": 106650,
       "name": "Scragnoth",
       "number": "83",
@@ -10375,7 +9212,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Side-effects of spells that would counter this card will still happen, because they happen even if the spell they're trying to counter can't be countered."
+          "text": "Side-effects of spells that would counter this card will still happen, because they happen even if the spell they’re trying to counter can’t be countered."
         },
         {
           "date": "2004-10-04",
@@ -10457,23 +9294,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -10485,15 +9310,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "84",
       "multiverseid": 108924,
       "name": "Spike Feeder",
       "number": "84",
@@ -10580,10 +9402,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10592,19 +9410,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10613,6 +9419,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "85",
       "multiverseid": 108855,
       "name": "Spitting Slug",
       "number": "85",
@@ -10695,10 +9502,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10707,19 +9510,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10728,6 +9519,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "86",
       "multiverseid": 108825,
       "name": "Thallid",
       "number": "86",
@@ -10814,10 +9606,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -10830,19 +9618,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10851,6 +9627,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "87",
       "multiverseid": 109745,
       "name": "Thornscape Battlemage",
       "number": "87",
@@ -10935,10 +9712,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -10951,19 +9724,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10972,6 +9733,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "88",
       "multiverseid": 109688,
       "name": "Verdeloth the Ancient",
       "number": "88",
@@ -10988,7 +9750,7 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "Verdeloth won't give himself +1/+1 unless he somehow becomes a Saproling."
+          "text": "Verdeloth won’t give himself +1/+1 unless he somehow becomes a Saproling."
         }
       ],
       "subtypes": [
@@ -11066,10 +9828,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11082,19 +9840,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11103,6 +9849,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "89",
       "multiverseid": 106662,
       "name": "Wall of Roots",
       "number": "89",
@@ -11188,10 +9935,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11200,19 +9943,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11221,6 +9952,7 @@
         }
       ],
       "manaCost": "{G}{G}",
+      "mciNumber": "90",
       "multiverseid": 109683,
       "name": "Whirling Dervish",
       "number": "90",
@@ -11324,10 +10056,6 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -11340,19 +10068,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11361,6 +10077,7 @@
         }
       ],
       "manaCost": "{3}{W}{U}{B}{R}{G}",
+      "mciNumber": "91",
       "multiverseid": 109718,
       "name": "Coalition Victory",
       "number": "91",
@@ -11449,10 +10166,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -11465,19 +10178,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11486,6 +10187,7 @@
         }
       ],
       "manaCost": "{R}{G}{W}",
+      "mciNumber": "92",
       "multiverseid": 108893,
       "name": "Fiery Justice",
       "number": "92",
@@ -11504,11 +10206,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can't choose zero targets. You must choose at least one target."
+          "text": "You can’t choose zero targets. You must choose at least one target."
         },
         {
           "date": "2006-09-25",
-          "text": "The opponent targeted for the life gain effect may also have been targeted by the damage effect. If this happens and the damage effect drops that player's life total to 0 or less, the life gain effect will raise his or her life total above 0 again before the player would lose the game."
+          "text": "The opponent targeted for the life gain effect may also have been targeted by the damage effect. If this happens and the damage effect drops that player’s life total to 0 or less, the life gain effect will raise his or her life total above 0 again before the player would lose the game."
         }
       ],
       "text": "Fiery Justice deals 5 damage divided as you choose among any number of target creatures and/or players. Target opponent gains 5 life.",
@@ -11581,10 +10283,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11593,19 +10291,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11614,6 +10300,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "93",
       "multiverseid": 109764,
       "name": "Jasmine Boreal",
       "number": "93",
@@ -11701,10 +10388,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -11717,19 +10400,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11738,6 +10409,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}{U}",
+      "mciNumber": "94",
       "multiverseid": 109746,
       "name": "Lightning Angel",
       "number": "94",
@@ -11826,10 +10498,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -11842,19 +10510,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11863,6 +10519,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}",
+      "mciNumber": "95",
       "multiverseid": 108871,
       "name": "Merieke Ri Berit",
       "number": "95",
@@ -11877,15 +10534,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Merieke becomes untapped, its \"destroy\" ability will trigger, but you won't lose control of the creature you took before it's destroyed."
+          "text": "If Merieke becomes untapped, its “destroy” ability will trigger, but you won’t lose control of the creature you took before it’s destroyed."
         },
         {
           "date": "2006-09-25",
-          "text": "If another player takes control of Merieke, you will immediately lose control of the creature you took, but Merieke's \"destroy\" ability won't trigger. The affected creature will go back under the control of the appropriate player."
+          "text": "If another player takes control of Merieke, you will immediately lose control of the creature you took, but Merieke’s “destroy” ability won’t trigger. The affected creature will go back under the control of the appropriate player."
         },
         {
           "date": "2006-09-25",
-          "text": "If Merieke leaves the battlefield, you will immediately lose control of the creature you took and Merieke's \"destroy\" ability will trigger. The affected creature will go back under the control of the appropriate player, then it will be destroyed."
+          "text": "If Merieke leaves the battlefield, you will immediately lose control of the creature you took and Merieke’s “destroy” ability will trigger. The affected creature will go back under the control of the appropriate player, then it will be destroyed."
         }
       ],
       "subtypes": [
@@ -11964,10 +10621,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11980,19 +10633,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12001,6 +10642,7 @@
         }
       ],
       "manaCost": "{2}{G}{W}",
+      "mciNumber": "96",
       "multiverseid": 108828,
       "name": "Mystic Enforcer",
       "number": "96",
@@ -12088,10 +10730,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -12104,19 +10742,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12125,6 +10751,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}{U}",
+      "mciNumber": "97",
       "multiverseid": 109693,
       "name": "Mystic Snake",
       "number": "97",
@@ -12213,10 +10840,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12225,19 +10848,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12246,6 +10857,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}{B}{B}{R}{R}",
+      "mciNumber": "98",
       "multiverseid": 109754,
       "name": "Nicol Bolas",
       "number": "98",
@@ -12263,7 +10875,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "Nicol Bolas's third ability triggers whenever it deals damage to an opponent for any reason. It's not limited to combat damage."
+          "text": "Nicol Bolas’s third ability triggers whenever it deals damage to an opponent for any reason. It’s not limited to combat damage."
         }
       ],
       "subtypes": [
@@ -12343,10 +10955,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12359,19 +10967,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12380,6 +10976,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "99",
       "multiverseid": 126333,
       "name": "Shadowmage Infiltrator",
       "number": "99",
@@ -12468,10 +11065,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12480,19 +11073,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12501,6 +11082,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}{R}",
+      "mciNumber": "100",
       "multiverseid": 109723,
       "name": "Sol'kanar the Swamp King",
       "number": "100",
@@ -12596,23 +11178,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -12624,15 +11194,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "101",
       "multiverseid": 109679,
       "name": "Spined Sliver",
       "number": "101",
@@ -12734,10 +11301,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -12750,19 +11313,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12771,6 +11322,7 @@
         }
       ],
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "102",
       "multiverseid": 109674,
       "name": "Stormbind",
       "number": "102",
@@ -12784,7 +11336,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Since the discard is a cost, it can't be used with Library of Leng."
+          "text": "Since the discard is a cost, it can’t be used with Library of Leng."
         }
       ],
       "text": "{2}, Discard a card at random: Stormbind deals 2 damage to target creature or player.",
@@ -12857,10 +11409,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -12873,19 +11421,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12894,6 +11430,7 @@
         }
       ],
       "manaCost": "{3}{W}{U}",
+      "mciNumber": "103",
       "multiverseid": 108787,
       "name": "Teferi's Moat",
       "number": "103",
@@ -12974,23 +11511,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -13002,15 +11527,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{2}{B}{G}",
+      "mciNumber": "104",
       "multiverseid": 109759,
       "name": "Vhati il-Dal",
       "number": "104",
@@ -13026,11 +11548,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You don't choose whether to affect the targeted creature's power or its toughness until the ability resolves."
+          "text": "You don’t choose whether to affect the targeted creature’s power or its toughness until the ability resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don't set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature's power and toughness. This card's effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
+          "text": "You apply power/toughness changing effects in a series of sublayers in the following order: (a) effects from characteristic-defining abilities; (b) effects that set power and/or toughness to a specific number or value; (c) effects that modify power and/or toughness but don’t set power and/or toughness to a specific number or value; (d) changes from counters; (e) effects that switch a creature’s power and toughness. This card’s effect is always applied in (b), which means that effects applied in sublayer (c), (d), or (e) will not be overwritten; they will be applied to the new value."
         }
       ],
       "subtypes": [
@@ -13110,10 +11632,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -13126,19 +11644,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13147,6 +11653,7 @@
         }
       ],
       "manaCost": "{3}{B}{R}",
+      "mciNumber": "105",
       "multiverseid": 109677,
       "name": "Void",
       "number": "105",
@@ -13231,10 +11738,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -13247,19 +11750,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13268,6 +11759,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "106a",
       "multiverseid": 109704,
       "name": "Assault",
       "names": [
@@ -13351,10 +11843,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -13367,19 +11855,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13388,6 +11864,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "106b",
       "multiverseid": 109704,
       "name": "Battery",
       "names": [
@@ -13465,10 +11942,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13477,19 +11950,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13502,6 +11963,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "107",
       "multiverseid": 109690,
       "name": "Claws of Gix",
       "number": "107",
@@ -13573,10 +12035,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
@@ -13589,19 +12047,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13610,6 +12056,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "108",
       "multiverseid": 109736,
       "name": "Dodecapod",
       "number": "108",
@@ -13688,10 +12135,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13700,19 +12143,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13721,6 +12152,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "109",
       "multiverseid": 109694,
       "name": "Feldon's Cane",
       "number": "109",
@@ -13794,10 +12226,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13810,19 +12238,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13831,6 +12247,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "110",
       "multiverseid": 109708,
       "name": "Grinning Totem",
       "number": "110",
@@ -13845,15 +12262,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent's library is empty); you can't fail to find anything."
+          "text": "You may choose to find any kind of card, including a land. You must exile a card (unless the opponent’s library is empty); you can’t fail to find anything."
         },
         {
           "date": "2006-09-25",
-          "text": "\"Until the beginning of your next upkeep\" means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
+          "text": "“Until the beginning of your next upkeep” means the effect wears off as soon as your next upkeep starts. Your last chance to play the card is usually the End step of the player who immediately precedes you."
         },
         {
           "date": "2006-09-25",
-          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You'll have to pay its mana cost. The only thing that's different is you're casting it from the Exile zone."
+          "text": "The exiled card is played using the normal rules for timing and priority for its card type, as well as any other applicable restrictions. You’ll have to pay its mana cost. The only thing that’s different is you’re casting it from the Exile zone."
         }
       ],
       "text": "{2}, {T}, Sacrifice Grinning Totem: Search target opponent's library for a card and exile it. Then that player shuffles his or her library. Until the beginning of your next upkeep, you may play that card. At the beginning of your next upkeep, if you haven't played it, put it into its owner's graveyard.",
@@ -13917,23 +12334,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -13945,15 +12350,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "111",
       "multiverseid": 108933,
       "name": "Mindless Automaton",
       "number": "111",
@@ -14033,10 +12435,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14049,19 +12447,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14070,6 +12456,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "112",
       "multiverseid": 109724,
       "name": "Mirari",
       "number": "112",
@@ -14097,11 +12484,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It triggers once per spell, so you can't get multiple copies of a spell using this card. And since this card is legendary, you can't control more than one."
+          "text": "It triggers once per spell, so you can’t get multiple copies of a spell using this card. And since this card is legendary, you can’t control more than one."
         },
         {
           "date": "2004-10-04",
-          "text": "The copy is not \"cast\" so it will not trigger anything that triggers on a spell being cast."
+          "text": "The copy is not “cast” so it will not trigger anything that triggers on a spell being cast."
         },
         {
           "date": "2004-10-04",
@@ -14109,7 +12496,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don't change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
+          "text": "You are not required to choose new targets. If you do choose, then the targets must be legal. If you don’t change them, the spell is placed on the stack whether or not the targets are legal. The legality of the targets is always checked on resolution of the spell, so the spell may be countered at that time if all of its targets are illegal."
         }
       ],
       "supertypes": [
@@ -14177,10 +12564,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14189,19 +12572,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14210,6 +12581,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "113",
       "multiverseid": 109725,
       "name": "The Rack",
       "number": "113",
@@ -14226,7 +12598,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You choose one opposing player as this card enters the battlefield and it only affects that one player. This choice is not changed even if this card changes controllers. It becomes useless but stays on the battlefield if the chosen player leaves the battlefield."
+          "text": "You choose one opposing player as this card enters the battlefield and it only affects that one player. This choice is not changed even if this card changes controllers. It becomes useless but stays on the battlefield if the chosen player leaves the game."
         }
       ],
       "text": "As The Rack enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, The Rack deals X damage to that player, where X is 3 minus the number of cards in his or her hand.",
@@ -14290,10 +12662,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14302,19 +12670,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14323,6 +12679,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "114",
       "multiverseid": 109730,
       "name": "Serrated Arrows",
       "number": "114",
@@ -14340,7 +12697,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you’ve somehow manage to get a new arrowhead counter on the Arrows."
         }
       ],
       "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
@@ -14405,10 +12762,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14417,19 +12770,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14438,6 +12779,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "115",
       "multiverseid": 109716,
       "name": "Tormod's Crypt",
       "number": "115",
@@ -14514,10 +12856,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14526,19 +12864,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14547,6 +12873,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "116",
       "multiverseid": 109757,
       "name": "War Barge",
       "number": "116",
@@ -14617,10 +12944,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14629,19 +12952,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14649,6 +12960,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "117",
       "multiverseid": 109739,
       "name": "Arena",
       "number": "117",
@@ -14737,10 +13049,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14749,19 +13057,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14769,6 +13065,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "118",
       "multiverseid": 109713,
       "name": "Desert",
       "number": "118",
@@ -14784,7 +13081,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The ability can be used on any player's attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
+          "text": "The ability can be used on any player’s attacking creatures. This includes your own and creatures in an attack you are not involved in (for multiplayer games)."
         }
       ],
       "subtypes": [
@@ -14850,10 +13147,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14866,19 +13159,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14886,6 +13167,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "119",
       "multiverseid": 109761,
       "name": "Gemstone Mine",
       "number": "119",
@@ -14904,7 +13186,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If the last mining counter is removed from Gemstone Mine in some way other than activating its ability (such as Chisei, Heart of Oceans), Gemstone Mine won't be sacrificed but its ability can't be activated."
+          "text": "If the last mining counter is removed from Gemstone Mine in some way other than activating its ability (such as Chisei, Heart of Oceans), Gemstone Mine won’t be sacrificed but its ability can’t be activated."
         }
       ],
       "text": "Gemstone Mine enters the battlefield with three mining counters on it.\n{T}, Remove a mining counter from Gemstone Mine: Add one mana of any color to your mana pool. If there are no mining counters on Gemstone Mine, sacrifice it.",
@@ -14971,10 +13253,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14983,19 +13261,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15003,6 +13269,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "120",
       "multiverseid": 109755,
       "name": "Pendelhaven",
       "number": "120",
@@ -15084,10 +13351,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15096,19 +13359,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15116,6 +13367,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "121",
       "multiverseid": 107275,
       "name": "Safe Haven",
       "number": "121",
@@ -15138,11 +13390,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If changed to another land type, the creature cards are not lost but can't be released until the land reverts to normal."
+          "text": "If changed to another land type, the creature cards are not lost but can’t be released until the land reverts to normal."
         },
         {
           "date": "2004-10-04",
-          "text": "When the creature leaves the battlefield any damage or \"will be destroyed at some future time\" effects are removed from the creature."
+          "text": "When the creature leaves the battlefield any damage or “will be destroyed at some future time” effects are removed from the creature."
         },
         {
           "date": "2004-10-04",

--- a/json/TSP.json
+++ b/json/TSP.json
@@ -23,6 +23,18 @@
     "common",
     "timeshifted purple"
   ],
+  "translations": {
+    "de": "Zeitspirale",
+    "fr": "Spirale Temporelle",
+    "it": "Spirale Temporale",
+    "es": "Espiral del Tiempo",
+    "pt": "Time Spiral",
+    "jp": "時のらせん",
+    "cn": "Time Spiral",
+    "ru": "Спираль времени"
+  },
+  "mkm_name": "Time Spiral",
+  "mkm_id": 56,
   "cards": [
     {
       "artist": "Quinton Hoover",
@@ -85,10 +97,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -97,19 +105,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -118,6 +114,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "1",
       "multiverseid": 113619,
       "name": "Amrou Scout",
       "number": "1",
@@ -202,10 +199,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -214,19 +207,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -235,6 +216,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "2",
       "multiverseid": 113509,
       "name": "Amrou Seekers",
       "number": "2",
@@ -317,10 +299,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -329,19 +307,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -350,6 +316,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "3",
       "multiverseid": 110504,
       "name": "Angel's Grace",
       "number": "3",
@@ -363,11 +330,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The last sentence applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
+          "text": "The last sentence applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2006-09-25",
-          "text": "You can't pay more life than you have."
+          "text": "You can’t pay more life than you have."
         },
         {
           "date": "2006-09-25",
@@ -375,11 +342,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "After the effect wears off during the cleanup step, you'll lose the game if your total is 0 or less (or you have ten or more poison counters)."
+          "text": "After the effect wears off during the cleanup step, you’ll lose the game if your total is 0 or less (or you have ten or more poison counters)."
         },
         {
           "date": "2006-09-25",
-          "text": "Angel's Grace doesn't prevent damage. It only changes the result of damage dealt to you. For example, a creature with lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 1."
+          "text": "Angel’s Grace doesn’t prevent damage. It only changes the result of damage dealt to you. For example, a creature with lifelink that deals damage to you will still cause its controller to gain life, even if that damage would reduce your life total to less than 1."
         },
         {
           "date": "2013-06-07",
@@ -387,23 +354,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
@@ -473,10 +440,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -485,19 +448,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -506,6 +457,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "4",
       "multiverseid": 122082,
       "name": "Benalish Cavalry",
       "number": "4",
@@ -588,10 +540,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -600,19 +548,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -621,6 +557,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "5",
       "multiverseid": 113614,
       "name": "Castle Raptors",
       "number": "5",
@@ -702,10 +639,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -714,19 +647,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -735,6 +656,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "6",
       "multiverseid": 108903,
       "name": "Cavalry Master",
       "number": "6",
@@ -752,7 +674,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a creature without flanking is given flanking by another effect, then this ability will grant a second instance. Similarly, if a creature loses flanking, then it won't get the Calvary Master instance either."
+          "text": "If a creature without flanking is given flanking by another effect, then this ability will grant a second instance. Similarly, if a creature loses flanking, then it won’t get the Calvary Master instance either."
         }
       ],
       "subtypes": [
@@ -826,10 +748,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -838,19 +756,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -859,6 +765,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "7",
       "multiverseid": 126281,
       "name": "Celestial Crusader",
       "number": "7",
@@ -878,23 +785,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "subtypes": [
@@ -968,10 +875,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -980,19 +883,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1001,6 +892,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "8",
       "multiverseid": 110525,
       "name": "Children of Korlis",
       "number": "8",
@@ -1014,7 +906,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If your life total drops to 0 or less, it's too late to use this ability before losing the game."
+          "text": "If your life total drops to 0 or less, it’s too late to use this ability before losing the game."
         },
         {
           "date": "2006-09-25",
@@ -1094,10 +986,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1106,19 +994,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1127,6 +1003,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "9",
       "multiverseid": 110502,
       "name": "Chronosavant",
       "number": "9",
@@ -1213,10 +1090,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1225,19 +1098,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1246,6 +1107,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "10",
       "multiverseid": 113507,
       "name": "Cloudchaser Kestrel",
       "number": "10",
@@ -1327,10 +1189,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1339,19 +1197,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1360,6 +1206,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 113518,
       "name": "D'Avenant Healer",
       "number": "11",
@@ -1443,10 +1290,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1455,19 +1298,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1476,6 +1307,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "12",
       "multiverseid": 116728,
       "name": "Detainment Spell",
       "number": "12",
@@ -1492,11 +1324,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Morph isn't an activated ability, so Detainment Spell doesn't prevent face-down creatures from being able to turn face up."
+          "text": "Morph isn’t an activated ability, so Detainment Spell doesn’t prevent face-down creatures from being able to turn face up."
         },
         {
           "date": "2006-09-25",
-          "text": "Responding to a creature's activated ability being activated by moving Detainment Spell onto that creature won't affect the ability that was just activated."
+          "text": "Responding to a creature’s activated ability being activated by moving Detainment Spell onto that creature won’t affect the ability that was just activated."
         }
       ],
       "subtypes": [
@@ -1568,10 +1400,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1580,19 +1408,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1601,6 +1417,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "13",
       "multiverseid": 108814,
       "name": "Divine Congregation",
       "number": "13",
@@ -1613,39 +1430,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1718,10 +1535,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1730,19 +1543,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1751,6 +1552,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "14",
       "multiverseid": 108887,
       "name": "Duskrider Peregrine",
       "number": "14",
@@ -1764,39 +1566,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -1874,10 +1676,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -1886,19 +1684,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1907,6 +1693,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "15",
       "multiverseid": 116379,
       "name": "Errant Doomsayers",
       "number": "15",
@@ -1988,10 +1775,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2000,19 +1783,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2021,6 +1792,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "16",
       "multiverseid": 110507,
       "name": "Evangelize",
       "number": "16",
@@ -2037,7 +1809,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The target of the spell is a creature the chosen opponent controls. As Evangelize resolves, if the target isn't a creature controlled by the chosen opponent, Evangelize will be countered. If Evangelize's target is changed (via Shunt, for example), the new target must be a creature controlled by the chosen opponent."
+          "text": "The target of the spell is a creature the chosen opponent controls. As Evangelize resolves, if the target isn’t a creature controlled by the chosen opponent, Evangelize will be countered. If Evangelize’s target is changed (via Shunt, for example), the new target must be a creature controlled by the chosen opponent."
         }
       ],
       "text": "Buyback {2}{W}{W} (You may pay an additional {2}{W}{W} as you cast this spell. If you do, put this card into your hand as it resolves.)\nGain control of target creature of an opponent's choice he or she controls.",
@@ -2107,10 +1879,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2119,19 +1887,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2140,6 +1896,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "17",
       "multiverseid": 108846,
       "name": "Flickering Spirit",
       "number": "17",
@@ -2153,15 +1910,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When the ability resolves, Flickering Spirit is exiled, then immediately returned to the battlefield. It returns as a \"new\" creature. Any counters, Auras, and so on are removed. Any spells or abilities targeting Flickering Spirit no longer target it."
+          "text": "When the ability resolves, Flickering Spirit is exiled, then immediately returned to the battlefield. It returns as a “new” creature. Any counters, Auras, and so on are removed. Any spells or abilities targeting Flickering Spirit no longer target it."
         },
         {
           "date": "2006-09-25",
-          "text": "If Flickering Spirit's ability is activated, any \"as this enters the battlefield\" choices for it are made by its owner, not its previous controller."
+          "text": "If Flickering Spirit’s ability is activated, any “as this enters the battlefield” choices for it are made by its owner, not its previous controller."
         },
         {
           "date": "2007-02-01",
-          "text": "If a token copy of Flickering Spirit uses its activated ability, the token will not return to the battlefield, because of the rule that says tokens that leave the battlefield can't return."
+          "text": "If a token copy of Flickering Spirit uses its activated ability, the token will not return to the battlefield, because of the rule that says tokens that leave the battlefield can’t return."
         }
       ],
       "subtypes": [
@@ -2235,10 +1992,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2247,19 +2000,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2268,6 +2009,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "18",
       "multiverseid": 106652,
       "name": "Foriysian Interceptor",
       "number": "18",
@@ -2285,14 +2027,14 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect says Foriysian Interceptor can't block, then it can't block any creatures."
+          "text": "If an effect says Foriysian Interceptor can’t block, then it can’t block any creatures."
         }
       ],
       "subtypes": [
         "Human",
         "Soldier"
       ],
-      "text": "Flash (You may cast this spell any time you could cast an instant.)\nDefender\nForiysian Interceptor can block an additional creature.",
+      "text": "Flash (You may cast this spell any time you could cast an instant.)\nDefender\nForiysian Interceptor can block an additional creature each combat.",
       "toughness": "5",
       "type": "Creature — Human Soldier",
       "types": [
@@ -2360,10 +2102,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2372,19 +2110,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2393,6 +2119,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "19",
       "multiverseid": 116732,
       "name": "Fortify",
       "number": "19",
@@ -2480,10 +2207,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2492,19 +2215,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2513,6 +2224,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "20",
       "multiverseid": 108819,
       "name": "Gaze of Justice",
       "number": "20",
@@ -2594,10 +2306,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2606,19 +2314,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2627,6 +2323,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "21",
       "multiverseid": 110514,
       "name": "Griffin Guide",
       "number": "21",
@@ -2642,7 +2339,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide's ability will trigger."
+          "text": "If Griffin Guide and the enchanted creature go to the graveyard at the same time, Griffin Guide’s ability will trigger."
         }
       ],
       "subtypes": [
@@ -2714,10 +2411,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2726,19 +2419,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2747,6 +2428,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "22",
       "multiverseid": 108889,
       "name": "Gustcloak Cavalier",
       "number": "22",
@@ -2829,10 +2511,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2841,19 +2519,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2862,6 +2528,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "23",
       "multiverseid": 108900,
       "name": "Icatian Crier",
       "number": "23",
@@ -2943,10 +2610,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -2955,19 +2618,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2976,6 +2627,7 @@
         }
       ],
       "manaCost": "{5}{W}{W}",
+      "mciNumber": "24",
       "multiverseid": 109741,
       "name": "Ivory Giant",
       "number": "24",
@@ -2990,39 +2642,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -3100,10 +2752,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3112,19 +2760,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3133,6 +2769,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "25",
       "multiverseid": 113571,
       "name": "Jedit's Dragoons",
       "number": "25",
@@ -3215,10 +2852,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3227,19 +2860,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3248,6 +2869,7 @@
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "26",
       "multiverseid": 118907,
       "name": "Knight of the Holy Nimbus",
       "number": "26",
@@ -3261,11 +2883,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The second ability essentially means that Knight of the Holy Nimbus always has a regeneration shield. It retains that shield even if it's used."
+          "text": "The second ability essentially means that Knight of the Holy Nimbus always has a regeneration shield. It retains that shield even if it’s used."
         },
         {
           "date": "2006-09-25",
-          "text": "After the third ability resolves, regeneration shields don't work on Knight of the Holy Nimbus for the remainder of the turn. This includes its own automatic shield as well as shields from other sources."
+          "text": "After the third ability resolves, regeneration shields don’t work on Knight of the Holy Nimbus for the remainder of the turn. This includes its own automatic shield as well as shields from other sources."
         }
       ],
       "subtypes": [
@@ -3341,10 +2963,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3353,19 +2971,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3374,6 +2980,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "27",
       "multiverseid": 126298,
       "name": "Magus of the Disk",
       "number": "27",
@@ -3387,7 +2994,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "If an effect gives Magus of the Disk indestructible or regenerates it, it won't be destroyed by its ability."
+          "text": "If an effect gives Magus of the Disk indestructible or regenerates it, it won’t be destroyed by its ability."
         }
       ],
       "subtypes": [
@@ -3462,10 +3069,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3474,19 +3077,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3495,6 +3086,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "28",
       "multiverseid": 113563,
       "name": "Mangara of Corondor",
       "number": "28",
@@ -3590,10 +3182,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3602,19 +3190,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3623,6 +3199,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "29",
       "multiverseid": 109733,
       "name": "Momentary Blink",
       "number": "29",
@@ -3640,11 +3217,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Any \"as this enters the battlefield\" choices for the affected creature are made by its owner, not its old controller."
+          "text": "Any “as this enters the battlefield” choices for the affected creature are made by its owner, not its old controller."
         },
         {
           "date": "2007-02-01",
-          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can't come back."
+          "text": "If Momentary Blink is cast on a token creature, the token will not return to the battlefield, because of the rule that says a token that leaves the battlefield can’t come back."
         }
       ],
       "text": "Exile target creature you control, then return it to the battlefield under its owner's control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
@@ -3714,10 +3291,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3726,19 +3299,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3747,6 +3308,7 @@
         }
       ],
       "manaCost": "{W}{W}{W}",
+      "mciNumber": "30",
       "multiverseid": 116747,
       "name": "Opal Guardian",
       "number": "30",
@@ -3759,7 +3321,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Guardian's effect doesn't wear off."
+          "text": "Guardian’s effect doesn’t wear off."
         },
         {
           "date": "2006-09-25",
@@ -3767,11 +3329,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "A face-down creature spell will cause Opal Guardian's ability to trigger (if it's an enchantment)."
+          "text": "A face-down creature spell will cause Opal Guardian’s ability to trigger (if it’s an enchantment)."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "When an opponent casts a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.",
@@ -3840,10 +3402,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3852,19 +3410,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3873,6 +3419,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "31",
       "multiverseid": 118902,
       "name": "Outrider en-Kor",
       "number": "31",
@@ -3894,7 +3441,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "When damage would be dealt to Outrider en-Kor, its controller chooses which redirection shields to apply out of all the shields that have been created that turn. It doesn't matter what order they were created in."
+          "text": "When damage would be dealt to Outrider en-Kor, its controller chooses which redirection shields to apply out of all the shields that have been created that turn. It doesn’t matter what order they were created in."
         }
       ],
       "subtypes": [
@@ -3969,10 +3516,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -3981,19 +3524,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4002,6 +3533,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}{W}",
+      "mciNumber": "32",
       "multiverseid": 110533,
       "name": "Pentarch Paladin",
       "number": "32",
@@ -4083,10 +3615,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4095,19 +3623,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4116,6 +3632,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "33",
       "multiverseid": 108874,
       "name": "Pentarch Ward",
       "number": "33",
@@ -4194,10 +3711,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4206,19 +3719,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4227,6 +3728,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "34",
       "multiverseid": 110510,
       "name": "Plated Pegasus",
       "number": "34",
@@ -4314,10 +3816,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4326,19 +3824,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4347,6 +3833,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "35",
       "multiverseid": 106657,
       "name": "Pull from Eternity",
       "number": "35",
@@ -4363,11 +3850,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Pull from Eternity affects a suspended card, the card loses its time counters and is no longer suspended. (This doesn't trigger the last ability of suspend.)"
+          "text": "If Pull from Eternity affects a suspended card, the card loses its time counters and is no longer suspended. (This doesn’t trigger the last ability of suspend.)"
         },
         {
           "date": "2006-09-25",
-          "text": "If Pull from Eternity affects a card that's haunting a creature, the haunt effect ends."
+          "text": "If Pull from Eternity affects a card that’s haunting a creature, the haunt effect ends."
         }
       ],
       "text": "Put target face-up exiled card into its owner's graveyard.",
@@ -4437,10 +3924,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4449,19 +3932,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4470,6 +3941,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "36",
       "multiverseid": 113575,
       "name": "Pulmonic Sliver",
       "number": "36",
@@ -4561,10 +4033,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4573,19 +4041,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4594,6 +4050,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "37",
       "multiverseid": 111051,
       "name": "Quilled Sliver",
       "number": "37",
@@ -4683,10 +4140,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4695,19 +4148,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4715,6 +4156,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "38",
       "multiverseid": 113520,
       "name": "Restore Balance",
       "number": "38",
@@ -4727,47 +4169,47 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind's Desire."
+          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
+          "text": "This has no mana cost, which means it can’t be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -4775,7 +4217,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Suspend 6—{W} (Rather than cast this card from your hand, pay {W} and exile it with six time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.",
@@ -4845,10 +4287,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4857,19 +4295,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4878,6 +4304,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "39",
       "multiverseid": 109709,
       "name": "Return to Dust",
       "number": "39",
@@ -4892,7 +4319,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there's only one legal target. If it's cast at a time other than its controller's main phase and a second target is chosen, nothing will happen to that target."
+          "text": "Regardless of when Return to Dust is cast, its controller may choose one target or two targets. It can always be cast even if there’s only one legal target. If it’s cast at a time other than its controller’s main phase and a second target is chosen, nothing will happen to that target."
         }
       ],
       "text": "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
@@ -4962,10 +4389,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -4974,19 +4397,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4995,6 +4406,7 @@
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "40",
       "multiverseid": 113519,
       "name": "Serra Avenger",
       "number": "40",
@@ -5010,7 +4422,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You can cast Serra Avenger during another player's first, second, or third turns of the game if some other effect (such as Vedalken Orrery) enables that."
+          "text": "You can cast Serra Avenger during another player’s first, second, or third turns of the game if some other effect (such as Vedalken Orrery) enables that."
         },
         {
           "date": "2012-07-01",
@@ -5018,7 +4430,7 @@
         },
         {
           "date": "2012-07-01",
-          "text": "If the game is restarted (by Karn Liberated), you can't cast Serra Avenger in your first, second, or third turn in the new game."
+          "text": "If the game is restarted (by Karn Liberated), you can’t cast Serra Avenger in your first, second, or third turn in the new game."
         }
       ],
       "subtypes": [
@@ -5092,10 +4504,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5104,19 +4512,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5125,6 +4521,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "41",
       "multiverseid": 118908,
       "name": "Sidewinder Sliver",
       "number": "41",
@@ -5215,10 +4612,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5227,19 +4620,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5248,6 +4629,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "42",
       "multiverseid": 109680,
       "name": "Spirit Loop",
       "number": "42",
@@ -5326,10 +4708,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5338,19 +4716,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5359,6 +4725,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "43",
       "multiverseid": 106654,
       "name": "Temporal Isolation",
       "number": "43",
@@ -5438,10 +4805,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5450,19 +4813,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5471,6 +4822,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "44",
       "multiverseid": 116736,
       "name": "Tivadar of Thorn",
       "number": "44",
@@ -5556,10 +4908,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5568,19 +4916,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5589,6 +4925,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "45",
       "multiverseid": 106648,
       "name": "Watcher Sliver",
       "number": "45",
@@ -5679,10 +5016,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5691,19 +5024,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5712,6 +5033,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "46",
       "multiverseid": 126283,
       "name": "Weathered Bodyguards",
       "number": "46",
@@ -5725,7 +5047,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Weathered Bodyguards affects only combat damage from unblocked creatures. It won't affect noncombat damage, and it won't affect trample damage."
+          "text": "Weathered Bodyguards affects only combat damage from unblocked creatures. It won’t affect noncombat damage, and it won’t affect trample damage."
         }
       ],
       "subtypes": [
@@ -5799,10 +5121,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -5811,19 +5129,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5832,6 +5138,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "47",
       "multiverseid": 108898,
       "name": "Zealot il-Vec",
       "number": "47",
@@ -5845,15 +5152,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When Zealot il-Vec attacks and isn't blocked, you must choose a target for its ability even if you don't use it."
+          "text": "When Zealot il-Vec attacks and isn’t blocked, you must choose a target for its ability even if you don’t use it."
         },
         {
           "date": "2006-09-25",
-          "text": "If you choose to have Zealot il-Vec deal 1 damage to a creature and that damage is prevented or replaced, Zealot il-Vec's combat damage will still be prevented."
+          "text": "If you choose to have Zealot il-Vec deal 1 damage to a creature and that damage is prevented or replaced, Zealot il-Vec’s combat damage will still be prevented."
         },
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -5926,23 +5233,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -5950,14 +5245,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
+      "mciNumber": "48",
       "multiverseid": 113505,
       "name": "Ancestral Vision",
       "number": "48",
@@ -5972,47 +5264,47 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind's Desire."
+          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
+          "text": "This has no mana cost, which means it can’t be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6020,7 +5312,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Suspend 4—{U} (Rather than cast this card from your hand, pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nTarget player draws three cards.",
@@ -6090,10 +5382,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6102,19 +5390,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6123,6 +5399,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "49",
       "multiverseid": 118901,
       "name": "Bewilder",
       "number": "49",
@@ -6199,10 +5476,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6211,19 +5484,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6232,6 +5493,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "50",
       "multiverseid": 118895,
       "name": "Brine Elemental",
       "number": "50",
@@ -6248,7 +5510,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Skipping the \"next\" step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player's opponents will each skip their next two untap steps."
+          "text": "Skipping the “next” step is cumulative. If a player turns two Brine Elementals face up on the same turn, that player’s opponents will each skip their next two untap steps."
         }
       ],
       "subtypes": [
@@ -6322,7 +5584,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
+          "format": "Khans of Tarkir Block",
           "legality": "Legal"
         },
         {
@@ -6334,10 +5596,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
           "format": "Return to Ravnica Block",
           "legality": "Legal"
         },
@@ -6346,27 +5604,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tarkir Block",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -6379,6 +5617,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "51",
       "multiverseid": 113523,
       "name": "Cancel",
       "number": "51",
@@ -6468,10 +5707,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6480,19 +5715,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6501,6 +5724,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "52",
       "multiverseid": 109691,
       "name": "Careful Consideration",
       "number": "52",
@@ -6577,10 +5801,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6589,19 +5809,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6610,6 +5818,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "53",
       "multiverseid": 109673,
       "name": "Clockspinning",
       "number": "53",
@@ -6622,7 +5831,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Clockspinning can affect any kind of counter, not just a time counter. The type of counter isn't chosen until resolution. Whether to add or remove a counter isn't chosen until resolution."
+          "text": "Clockspinning can affect any kind of counter, not just a time counter. The type of counter isn’t chosen until resolution. Whether to add or remove a counter isn’t chosen until resolution."
         },
         {
           "date": "2006-09-25",
@@ -6630,39 +5839,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -6736,10 +5945,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6748,19 +5953,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6769,6 +5962,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "54",
       "multiverseid": 110511,
       "name": "Coral Trickster",
       "number": "54",
@@ -6851,10 +6045,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6863,19 +6053,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6884,6 +6062,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "55",
       "multiverseid": 106668,
       "name": "Crookclaw Transmuter",
       "number": "55",
@@ -6902,7 +6081,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -6977,10 +6156,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6989,19 +6164,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7010,6 +6173,7 @@
         }
       ],
       "manaCost": "{7}{U}{U}{U}",
+      "mciNumber": "56",
       "multiverseid": 113506,
       "name": "Deep-Sea Kraken",
       "number": "56",
@@ -7024,39 +6188,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -7133,10 +6297,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7145,19 +6305,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7166,6 +6314,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "57",
       "multiverseid": 111057,
       "name": "Draining Whelk",
       "number": "57",
@@ -7179,11 +6328,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If the triggered ability is countered (the targeted spell becomes an illegal target, for example), Draining Whelk doesn't get any +1/+1 counters."
+          "text": "If the triggered ability is countered (the targeted spell becomes an illegal target, for example), Draining Whelk doesn’t get any +1/+1 counters."
         },
         {
           "date": "2006-10-15",
-          "text": "If the triggered ability doesn't counter the spell (if it is, for example, uncounterable), Draining Whelk still gets the counters."
+          "text": "If the triggered ability doesn’t counter the spell (if it is, for example, uncounterable), Draining Whelk still gets the counters."
         }
       ],
       "subtypes": [
@@ -7257,10 +6406,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7269,19 +6414,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7290,6 +6423,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "58",
       "multiverseid": 108858,
       "name": "Dream Stalker",
       "number": "58",
@@ -7372,10 +6506,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7384,19 +6514,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7405,6 +6523,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "59",
       "multiverseid": 108918,
       "name": "Drifter il-Dal",
       "number": "59",
@@ -7486,10 +6605,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7498,19 +6613,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7519,6 +6622,7 @@
         }
       ],
       "manaCost": "{6}{U}",
+      "mciNumber": "60",
       "multiverseid": 108909,
       "name": "Errant Ephemeron",
       "number": "60",
@@ -7536,39 +6640,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -7645,23 +6749,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -7673,15 +6765,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "61",
       "multiverseid": 108788,
       "name": "Eternity Snare",
       "number": "61",
@@ -7761,10 +6850,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7773,19 +6858,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7794,6 +6867,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "62",
       "multiverseid": 118912,
       "name": "Fathom Seer",
       "number": "62",
@@ -7878,10 +6952,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -7890,19 +6960,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7911,6 +6969,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "63",
       "multiverseid": 110532,
       "name": "Fledgling Mawcor",
       "number": "63",
@@ -7993,10 +7052,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8005,19 +7060,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8026,6 +7069,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "64",
       "multiverseid": 126294,
       "name": "Fool's Demise",
       "number": "64",
@@ -8039,7 +7083,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Fool's Demise and the enchanted creature go to the graveyard from the battlefield at the same time, both abilities will trigger."
+          "text": "If Fool’s Demise and the enchanted creature go to the graveyard from the battlefield at the same time, both abilities will trigger."
         }
       ],
       "subtypes": [
@@ -8111,10 +7155,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8123,19 +7163,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8144,6 +7172,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "65",
       "multiverseid": 124313,
       "name": "Ixidron",
       "number": "65",
@@ -8166,15 +7195,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The controller of a face-down creature can look at it at any time, even if it doesn't have morph. Other players can't, but the rules for face-down permanents state that \"you must ensure at all times that your face-down spells and permanents can be easily differentiated from each other.\" As a result, all players must be able to figure out what each of the creatures Ixidron turned face down is."
+          "text": "The controller of a face-down creature can look at it at any time, even if it doesn’t have morph. Other players can’t, but the rules for face-down permanents state that “you must ensure at all times that your face-down spells and permanents can be easily differentiated from each other.” As a result, all players must be able to figure out what each of the creatures Ixidron turned face down is."
         },
         {
           "date": "2006-09-25",
-          "text": "You turn the creatures face-down *as* Ixidron enters the battlefield. There is never a moment when Ixidron is on the battlefield and the creatures are face-up. If a creature on the battlefield has a \"whenever another creature enters the battlefield\" ability, it won't trigger because that creature will be face down before Ixidron enters the battlefield."
+          "text": "You turn the creatures face-down *as* Ixidron enters the battlefield. There is never a moment when Ixidron is on the battlefield and the creatures are face-up. If a creature on the battlefield has a “whenever another creature enters the battlefield” ability, it won’t trigger because that creature will be face down before Ixidron enters the battlefield."
         },
         {
           "date": "2006-09-25",
-          "text": "Turning a face-down creature face-down typically has no effect; the creature's status is unchanged."
+          "text": "Turning a face-down creature face-down typically has no effect; the creature’s status is unchanged."
         }
       ],
       "subtypes": [
@@ -8248,10 +7277,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8260,19 +7285,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8281,6 +7294,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "66",
       "multiverseid": 118918,
       "name": "Looter il-Kor",
       "number": "66",
@@ -8362,10 +7376,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8374,19 +7384,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8395,6 +7393,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "67",
       "multiverseid": 126287,
       "name": "Magus of the Jar",
       "number": "67",
@@ -8477,10 +7476,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8489,19 +7484,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8510,6 +7493,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "68",
       "multiverseid": 116391,
       "name": "Moonlace",
       "number": "68",
@@ -8522,7 +7506,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Moonlace's effect doesn't wear off."
+          "text": "Moonlace’s effect doesn’t wear off."
         },
         {
           "date": "2006-09-25",
@@ -8596,10 +7580,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8608,19 +7588,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8629,6 +7597,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "69",
       "multiverseid": 111058,
       "name": "Mystical Teachings",
       "number": "69",
@@ -8704,10 +7673,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8716,19 +7681,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8737,6 +7690,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "70",
       "multiverseid": 108795,
       "name": "Ophidian Eye",
       "number": "70",
@@ -8822,10 +7776,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8834,19 +7784,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8855,6 +7793,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "71",
       "multiverseid": 109721,
       "name": "Paradox Haze",
       "number": "71",
@@ -8867,23 +7806,23 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Paradox Haze targets a player when it's cast, and it enters the battlefield attached to that player."
+          "text": "Paradox Haze targets a player when it’s cast, and it enters the battlefield attached to that player."
         },
         {
           "date": "2006-09-25",
-          "text": "If two Paradox Hazes enchant the same player, they'll both trigger when that player's first upkeep of the turn begins. The player will get two additional upkeep steps."
+          "text": "If two Paradox Hazes enchant the same player, they’ll both trigger when that player’s first upkeep of the turn begins. The player will get two additional upkeep steps."
         },
         {
           "date": "2006-09-25",
-          "text": "Abilities that trigger \"at the beginning of [your] upkeep\" will trigger at the beginning of each additional upkeep as well."
+          "text": "Abilities that trigger “at the beginning of [your] upkeep” will trigger at the beginning of each additional upkeep as well."
         },
         {
           "date": "2006-09-25",
-          "text": "If echo triggers during the first upkeep, it won't trigger again during the second upkeep since the creature won't have enter the battlefield since that player's last upkeep."
+          "text": "If echo triggers during the first upkeep, it won’t trigger again during the second upkeep since the creature won’t have enter the battlefield since that player’s last upkeep."
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect causes the enchanted player to skip his or her upkeep step, this ability won't trigger."
+          "text": "If an effect causes the enchanted player to skip his or her upkeep step, this ability won’t trigger."
         }
       ],
       "subtypes": [
@@ -8956,10 +7895,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -8968,19 +7903,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8989,6 +7912,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "72",
       "multiverseid": 113559,
       "name": "Psionic Sliver",
       "number": "72",
@@ -9079,10 +8003,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9091,19 +8011,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9112,6 +8020,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "73",
       "multiverseid": 109715,
       "name": "Riftwing Cloudskate",
       "number": "73",
@@ -9129,39 +8038,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -9239,10 +8148,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9251,19 +8156,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9272,6 +8165,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "74",
       "multiverseid": 118914,
       "name": "Sage of Epityr",
       "number": "74",
@@ -9354,10 +8248,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9366,19 +8256,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9387,6 +8265,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "75",
       "multiverseid": 122387,
       "name": "Screeching Sliver",
       "number": "75",
@@ -9478,10 +8357,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9490,19 +8365,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9511,6 +8374,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "76",
       "multiverseid": 108797,
       "name": "Shadow Sliver",
       "number": "76",
@@ -9601,10 +8465,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9613,19 +8473,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9634,6 +8482,7 @@
         }
       ],
       "manaCost": "{7}{U}",
+      "mciNumber": "77",
       "multiverseid": 116385,
       "name": "Slipstream Serpent",
       "number": "77",
@@ -9715,10 +8564,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9727,19 +8572,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9748,6 +8581,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "78",
       "multiverseid": 108897,
       "name": "Snapback",
       "number": "78",
@@ -9824,10 +8658,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9836,19 +8666,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9857,6 +8675,7 @@
         }
       ],
       "manaCost": "{X}{U}",
+      "mciNumber": "79",
       "multiverseid": 109707,
       "name": "Spell Burst",
       "number": "79",
@@ -9933,10 +8752,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -9945,19 +8760,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9966,6 +8769,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "80",
       "multiverseid": 118913,
       "name": "Spiketail Drakeling",
       "number": "80",
@@ -10047,10 +8851,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10059,19 +8859,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10080,6 +8868,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "81",
       "multiverseid": 116386,
       "name": "Sprite Noble",
       "number": "81",
@@ -10162,10 +8951,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10174,19 +8959,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10195,6 +8968,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "82",
       "multiverseid": 118894,
       "name": "Stormcloud Djinn",
       "number": "82",
@@ -10276,10 +9050,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10288,19 +9058,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10309,6 +9067,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}{U}",
+      "mciNumber": "83",
       "multiverseid": 121271,
       "name": "Teferi, Mage of Zhalfir",
       "number": "83",
@@ -10323,7 +9082,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The last ability means that in order for an opponent to cast a spell, it must be that opponent's turn, during a main phase, and the stack must be empty. This is true even if the player doesn't have a sorcery he or she is able to cast, or if a rule or effect allows a spell to be cast at another time."
+          "text": "The last ability means that in order for an opponent to cast a spell, it must be that opponent’s turn, during a main phase, and the stack must be empty. This is true even if the player doesn’t have a sorcery he or she is able to cast, or if a rule or effect allows a spell to be cast at another time."
         },
         {
           "date": "2006-09-25",
@@ -10331,15 +9090,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an ability lets an opponent cast a spell as part of its effect (such as Isochron Scepter's ability does), that opponent can't cast that spell since the currently resolving ability is still on the stack."
+          "text": "If an ability lets an opponent cast a spell as part of its effect (such as Isochron Scepter’s ability does), that opponent can’t cast that spell since the currently resolving ability is still on the stack."
         },
         {
           "date": "2006-09-25",
-          "text": "Your opponents can't cast their suspended cards, no matter what phase it is when the last time counter is removed. Your opponents can't cast cards using the madness ability either, no matter what phase it is when the card is discarded."
+          "text": "Your opponents can’t cast their suspended cards, no matter what phase it is when the last time counter is removed. Your opponents can’t cast cards using the madness ability either, no matter what phase it is when the card is discarded."
         },
         {
           "date": "2007-05-01",
-          "text": "If you have Teferi on the battlefield and there's a Split Second spell on the stack (such as Sudden Death), you can't Suspend creatures until after the Split Second spell resolves."
+          "text": "If you have Teferi on the battlefield and there’s a Split Second spell on the stack (such as Sudden Death), you can’t Suspend creatures until after the Split Second spell resolves."
         }
       ],
       "subtypes": [
@@ -10417,10 +9176,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10429,19 +9184,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10450,6 +9193,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "84",
       "multiverseid": 111085,
       "name": "Telekinetic Sliver",
       "number": "84",
@@ -10541,10 +9285,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10553,19 +9293,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10574,6 +9302,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "85",
       "multiverseid": 118887,
       "name": "Temporal Eddy",
       "number": "85",
@@ -10650,10 +9379,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Innistrad Block",
           "legality": "Legal"
         },
@@ -10666,19 +9391,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10687,6 +9400,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "86",
       "multiverseid": 108823,
       "name": "Think Twice",
       "number": "86",
@@ -10764,10 +9478,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10776,19 +9486,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10797,6 +9495,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "87",
       "multiverseid": 108907,
       "name": "Tolarian Sentinel",
       "number": "87",
@@ -10878,10 +9577,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -10890,19 +9585,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10911,6 +9594,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "88",
       "multiverseid": 110499,
       "name": "Trickbind",
       "number": "88",
@@ -10927,7 +9611,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can be used to counter the storm triggered ability. Doing so prevents the copies from being created, but doesn't counter the original storm spell."
+          "text": "Trickbind can be used to counter the storm triggered ability. Doing so prevents the copies from being created, but doesn’t counter the original storm spell."
         },
         {
           "date": "2006-09-25",
@@ -10935,11 +9619,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can be used to counter the suspend \"remove a counter\" ability. If so, the counter won't get removed, but the ability will trigger again as normal later on. Trickbind can also be used to counter the suspend \"play this card\" ability. If so, the card stays exiled (the ability won't trigger again). Using suspend to exile a card in your hand is neither an activated nor a triggered ability, so it can't be countered this way."
+          "text": "Trickbind can be used to counter the suspend “remove a counter” ability. If so, the counter won’t get removed, but the ability will trigger again as normal later on. Trickbind can also be used to counter the suspend “play this card” ability. If so, the card stays exiled (the ability won’t trigger again). Using suspend to exile a card in your hand is neither an activated nor a triggered ability, so it can’t be countered this way."
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can be used to counter the echo triggered ability. If so, the echo ability won't trigger again so the echo cost is never paid."
+          "text": "Trickbind can be used to counter the echo triggered ability. If so, the echo ability won’t trigger again so the echo cost is never paid."
         },
         {
           "date": "2006-09-25",
@@ -10947,7 +9631,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "Trickbind can't counter or prevent paying the morph cost to turn a face-down creature face up, since that action doesn't use the stack."
+          "text": "Trickbind can’t counter or prevent paying the morph cost to turn a face-down creature face up, since that action doesn’t use the stack."
         },
         {
           "date": "2013-06-07",
@@ -10955,27 +9639,27 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         },
         {
           "date": "2013-07-01",
-          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder texts."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nCounter target activated or triggered ability. If a permanent's ability is countered this way, activated abilities of that permanent can't be activated this turn. (Mana abilities can't be targeted.)",
@@ -11044,10 +9728,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11056,19 +9736,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11077,6 +9745,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "89",
       "multiverseid": 118910,
       "name": "Truth or Tale",
       "number": "89",
@@ -11089,7 +9758,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Here's how this works: Step 1: You reveal the top five cards of your library. Step 2: You separate those cards into two piles. (A pile can have zero cards.) Step 3: An opponent of your choice chooses one of those piles. Step 4: You choose one of the cards in the chosen pile. Step 5: You put the chosen card in your hand. Step 6: You put all other revealed cards (from both piles) on the bottom of your library in any order."
+          "text": "Here’s how this works: Step 1: You reveal the top five cards of your library. Step 2: You separate those cards into two piles. (A pile can have zero cards.) Step 3: An opponent of your choice chooses one of those piles. Step 4: You choose one of the cards in the chosen pile. Step 5: You put the chosen card in your hand. Step 6: You put all other revealed cards (from both piles) on the bottom of your library in any order."
         }
       ],
       "text": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put a card from the chosen pile into your hand, then put all other cards revealed this way on the bottom of your library in any order.",
@@ -11158,10 +9827,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11170,19 +9835,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11191,6 +9844,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "90",
       "multiverseid": 109765,
       "name": "Vesuvan Shapeshifter",
       "number": "90",
@@ -11204,7 +9858,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Essentially, each time Vesuvan Shapeshifter turns face up, it's a copy of a new creature. During your upkeep, you may turn it face down in preparation to copy something else."
+          "text": "Essentially, each time Vesuvan Shapeshifter turns face up, it’s a copy of a new creature. During your upkeep, you may turn it face down in preparation to copy something else."
         },
         {
           "date": "2006-09-25",
@@ -11212,15 +9866,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If Vesuvan Shapeshifter is turned face up, the process of turning face up includes (optionally) choosing another creature on the battlefield. You'll pay {1}{U} (not the morph cost, if any, of the new creature), then Vesuvan Shapeshifter will turn face up as a copy of that creature, plus the triggered ability it gives itself. It won't turn face up as a Vesuvan Shapeshifter and then change. If the copied creature has a \"when this creature is turned face up\" ability, it will trigger for Vesuvan Shapeshifter."
+          "text": "If Vesuvan Shapeshifter is turned face up, the process of turning face up includes (optionally) choosing another creature on the battlefield. You’ll pay {1}{U} (not the morph cost, if any, of the new creature), then Vesuvan Shapeshifter will turn face up as a copy of that creature, plus the triggered ability it gives itself. It won’t turn face up as a Vesuvan Shapeshifter and then change. If the copied creature has a “when this creature is turned face up” ability, it will trigger for Vesuvan Shapeshifter."
         },
         {
           "date": "2006-09-25",
-          "text": "When Vesuvan Shapeshifter is turned face down, its copy effect wears off. While it's face down, it's a face-down Vesuvan Shapeshifter that can be turned face up for a morph cost of {1}{U}."
+          "text": "When Vesuvan Shapeshifter is turned face down, its copy effect wears off. While it’s face down, it’s a face-down Vesuvan Shapeshifter that can be turned face up for a morph cost of {1}{U}."
         },
         {
           "date": "2006-09-25",
-          "text": "If another creature copies Vesuvan Shapeshifter while it's face up, the new creature will become a copy of whatever Vesuvan Shapeshifter is copying and gain the \"you may turn this creature face down\" ability. It won't gain morph {1}{U}. If that creature is then turned face down, its copy effect will continue and it'll be a face-down version of whatever it's copying. If the creature it's copying has morph, it can be turned face up. If the creature it's copying doesn't have morph, it's stuck face down forever unless some other effect (like Break Open) turns it face up again."
+          "text": "If another creature copies Vesuvan Shapeshifter while it’s face up, the new creature will become a copy of whatever Vesuvan Shapeshifter is copying and gain the “you may turn this creature face down” ability. It won’t gain morph {1}{U}. If that creature is then turned face down, its copy effect will continue and it’ll be a face-down version of whatever it’s copying. If the creature it’s copying has morph, it can be turned face up. If the creature it’s copying doesn’t have morph, it’s stuck face down forever unless some other effect (like Break Open) turns it face up again."
         },
         {
           "date": "2006-09-25",
@@ -11228,15 +9882,15 @@
         },
         {
           "date": "2006-09-25",
-          "text": "When Vesuvan Shapeshifter copies a creature that has echo, the echo ability will trigger at the beginning of your upkeep if Vesuvan Shapeshifter came under your control since the beginning of your last upkeep. If you've controlled Vesuvan Shapeshifter since your last upkeep (regardless of whether it had echo then), the echo ability won't trigger."
+          "text": "When Vesuvan Shapeshifter copies a creature that has echo, the echo ability will trigger at the beginning of your upkeep if Vesuvan Shapeshifter came under your control since the beginning of your last upkeep. If you’ve controlled Vesuvan Shapeshifter since your last upkeep (regardless of whether it had echo then), the echo ability won’t trigger."
         },
         {
           "date": "2006-09-25",
-          "text": "Turning Vesuvan Shapeshifter face down during your upkeep doesn't prevent you from needing to pay applicable upkeep costs such as echo."
+          "text": "Turning Vesuvan Shapeshifter face down during your upkeep doesn’t prevent you from needing to pay applicable upkeep costs such as echo."
         },
         {
           "date": "2006-09-25",
-          "text": "If you don't or can't choose another creature on the battlefield for Vesuvan Shapeshifter to copy, it doesn't get the triggered ability that turns it face down. It's just a 0/0 creature with morph {1}{U}."
+          "text": "If you don’t or can’t choose another creature on the battlefield for Vesuvan Shapeshifter to copy, it doesn’t get the triggered ability that turns it face down. It’s just a 0/0 creature with morph {1}{U}."
         }
       ],
       "subtypes": [
@@ -11309,10 +9963,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11321,19 +9971,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11342,6 +9980,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "91",
       "multiverseid": 113615,
       "name": "Viscerid Deepwalker",
       "number": "91",
@@ -11355,39 +9994,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -11465,10 +10104,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11477,19 +10112,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11498,6 +10121,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "92",
       "multiverseid": 111076,
       "name": "Voidmage Husher",
       "number": "92",
@@ -11512,7 +10136,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder texts."
         }
       ],
       "subtypes": [
@@ -11586,10 +10210,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11598,19 +10218,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11619,6 +10227,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "93",
       "multiverseid": 110517,
       "name": "Walk the Aeons",
       "number": "93",
@@ -11695,10 +10304,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11707,19 +10312,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11728,6 +10321,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "94",
       "multiverseid": 118911,
       "name": "Wipe Away",
       "number": "94",
@@ -11744,23 +10338,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nReturn target permanent to its owner's hand.",
@@ -11830,10 +10424,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11842,19 +10432,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11863,6 +10441,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "95",
       "multiverseid": 114918,
       "name": "Assassinate",
       "number": "95",
@@ -11944,10 +10523,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -11956,19 +10531,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11977,6 +10540,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "96",
       "multiverseid": 108792,
       "name": "Basal Sliver",
       "number": "96",
@@ -12068,10 +10632,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12080,19 +10640,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12101,6 +10649,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "97",
       "multiverseid": 108832,
       "name": "Call to the Netherworld",
       "number": "97",
@@ -12110,7 +10659,7 @@
         "TSP"
       ],
       "rarity": "Common",
-      "text": "Return target black creature card from your graveyard to your hand.\nMadness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Return target black creature card from your graveyard to your hand.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -12176,10 +10725,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12188,19 +10733,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12209,6 +10742,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "98",
       "multiverseid": 108910,
       "name": "Corpulent Corpse",
       "number": "98",
@@ -12222,39 +10756,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -12331,10 +10865,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12343,19 +10873,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12364,6 +10882,7 @@
         }
       ],
       "manaCost": "{9}{B}",
+      "mciNumber": "99",
       "multiverseid": 111049,
       "name": "Curse of the Cabal",
       "number": "99",
@@ -12376,39 +10895,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -12482,10 +11001,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12494,19 +11009,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12515,6 +11018,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "100",
       "multiverseid": 114915,
       "name": "Cyclopean Giant",
       "number": "100",
@@ -12532,7 +11036,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a Vesuvan Shapeshifter that's copying Cyclopean Giant is put into a graveyard, the Shapeshifter will be exiled when the ability resolves even though it's not a Cyclopean Giant anymore."
+          "text": "If a Vesuvan Shapeshifter that’s copying Cyclopean Giant is put into a graveyard, the Shapeshifter will be exiled when the ability resolves even though it’s not a Cyclopean Giant anymore."
         }
       ],
       "subtypes": [
@@ -12606,10 +11110,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12618,19 +11118,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12639,6 +11127,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "101",
       "multiverseid": 118892,
       "name": "Dark Withering",
       "number": "101",
@@ -12648,7 +11137,7 @@
         "TSP"
       ],
       "rarity": "Common",
-      "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -12714,10 +11203,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12726,19 +11211,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12747,6 +11220,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "102",
       "multiverseid": 116743,
       "name": "Deathspore Thallid",
       "number": "102",
@@ -12828,10 +11302,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12840,19 +11310,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12861,6 +11319,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "103",
       "multiverseid": 118872,
       "name": "Demonic Collusion",
       "number": "103",
@@ -12937,10 +11396,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12949,19 +11404,7 @@
           "legality": "Banned"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12970,6 +11413,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "104",
       "multiverseid": 116721,
       "name": "Dread Return",
       "number": "104",
@@ -13049,10 +11493,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13061,19 +11501,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13082,6 +11510,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "105",
       "multiverseid": 108850,
       "name": "Drudge Reavers",
       "number": "105",
@@ -13162,10 +11591,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13174,19 +11599,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13195,6 +11608,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "106",
       "multiverseid": 113527,
       "name": "Endrek Sahr, Master Breeder",
       "number": "106",
@@ -13210,11 +11624,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The second ability is a state trigger. Once it triggers, it won't trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
+          "text": "The second ability is a state trigger. Once it triggers, it won’t trigger again as long as the ability is on the stack. If the ability is countered and the trigger condition is still true, it will immediately trigger again."
         },
         {
           "date": "2006-09-25",
-          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it's less than seven."
+          "text": "When the second ability resolves, Endrek Sahr will be sacrificed regardless of how many Thrulls you control at that time, even if it’s less than seven."
         },
         {
           "date": "2006-09-25",
@@ -13296,10 +11710,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13308,19 +11718,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13329,6 +11727,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "107",
       "multiverseid": 83811,
       "name": "Evil Eye of Urborg",
       "number": "107",
@@ -13409,10 +11808,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13421,19 +11816,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13442,6 +11825,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "108",
       "multiverseid": 109719,
       "name": "Faceless Devourer",
       "number": "108",
@@ -13529,10 +11913,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13541,19 +11921,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13562,6 +11930,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "109",
       "multiverseid": 114908,
       "name": "Fallen Ideal",
       "number": "109",
@@ -13575,7 +11944,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The creature's controller (not Fallen Ideal's controller) can activate the \"sacrifice a creature\" ability."
+          "text": "The creature’s controller (not Fallen Ideal’s controller) can activate the “sacrifice a creature” ability."
         }
       ],
       "subtypes": [
@@ -13648,10 +12017,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13660,19 +12025,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13681,6 +12034,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "110",
       "multiverseid": 108892,
       "name": "Feebleness",
       "number": "110",
@@ -13759,10 +12113,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13771,19 +12121,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13792,6 +12130,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "111",
       "multiverseid": 118923,
       "name": "Gorgon Recluse",
       "number": "111",
@@ -13805,7 +12144,7 @@
       "subtypes": [
         "Gorgon"
       ],
-      "text": "Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.\nMadness {B}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat.\nMadness {B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "4",
       "type": "Creature — Gorgon",
       "types": [
@@ -13873,10 +12212,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13885,19 +12220,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13906,6 +12229,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "112",
       "multiverseid": 109731,
       "name": "Haunting Hymn",
       "number": "112",
@@ -13981,10 +12305,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -13993,19 +12313,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14014,6 +12322,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}{B}",
+      "mciNumber": "113",
       "multiverseid": 126285,
       "name": "Liege of the Pit",
       "number": "113",
@@ -14027,11 +12336,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You can't sacrifice Liege of the Pit to its own ability. You can sacrifice one Liege of the Pit to another Liege of the Pit."
+          "text": "You can’t sacrifice Liege of the Pit to its own ability. You can sacrifice one Liege of the Pit to another Liege of the Pit."
         },
         {
           "date": "2006-09-25",
-          "text": "If you have another creature on the battlefield when the ability resolves, you must sacrifice it. You can't choose to be dealt 7 damage instead."
+          "text": "If you have another creature on the battlefield when the ability resolves, you must sacrifice it. You can’t choose to be dealt 7 damage instead."
         }
       ],
       "subtypes": [
@@ -14104,10 +12413,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14116,19 +12421,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14137,6 +12430,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "114",
       "multiverseid": 113522,
       "name": "Lim-Dûl the Necromancer",
       "number": "114",
@@ -14220,10 +12514,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14232,19 +12522,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14252,6 +12530,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "115",
       "multiverseid": 113521,
       "name": "Living End",
       "number": "115",
@@ -14264,51 +12543,51 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
+          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind's Desire."
+          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
+          "text": "This has no mana cost, which means it can’t be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14316,7 +12595,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Suspend 3—{2}{B}{B} (Rather than cast this card from your hand, pay {2}{B}{B} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -14386,10 +12665,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14398,19 +12673,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14419,6 +12682,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "116",
       "multiverseid": 126278,
       "name": "Magus of the Mirror",
       "number": "116",
@@ -14433,11 +12697,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player's previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
+          "text": "When the life totals are exchanged, each player gains or loses the amount of life necessary to equal the other player’s previous life total. For example, if player A has 5 life and player B has 3 life before the exchange, player A will lose 2 life and player B will gain 2 life. Replacement effects may modify these gains and losses, and triggered abilities may trigger on them."
         },
         {
           "date": "2011-01-01",
-          "text": "If an effect says that a player can't lose life, that player can't exchange life totals with a player who has a lower life total; in that case, the exchange won't happen."
+          "text": "If an effect says that a player can’t lose life, that player can’t exchange life totals with a player who has a lower life total; in that case, the exchange won’t happen."
         }
       ],
       "subtypes": [
@@ -14512,10 +12776,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14524,19 +12784,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14545,6 +12793,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "117",
       "multiverseid": 106658,
       "name": "Mana Skimmer",
       "number": "117",
@@ -14626,10 +12875,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14638,19 +12883,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14659,6 +12892,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "118",
       "multiverseid": 118867,
       "name": "Mindlash Sliver",
       "number": "118",
@@ -14749,10 +12983,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14761,19 +12991,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14782,6 +13000,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "119",
       "multiverseid": 108894,
       "name": "Mindstab",
       "number": "119",
@@ -14794,39 +13013,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -14899,10 +13118,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -14911,19 +13126,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14932,6 +13135,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "120",
       "multiverseid": 116742,
       "name": "Nether Traitor",
       "number": "120",
@@ -14945,7 +13149,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Nether Traitor and another creature are put into your graveyard at the same time, Nether Traitor's ability won't trigger."
+          "text": "If Nether Traitor and another creature are put into your graveyard at the same time, Nether Traitor’s ability won’t trigger."
         }
       ],
       "subtypes": [
@@ -15018,10 +13222,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15030,19 +13230,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15051,6 +13239,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "121",
       "multiverseid": 111079,
       "name": "Nightshade Assassin",
       "number": "121",
@@ -15075,7 +13264,7 @@
         "Human",
         "Assassin"
       ],
-      "text": "First strike\nWhen Nightshade Assassin enters the battlefield, you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn.\nMadness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "First strike\nWhen Nightshade Assassin enters the battlefield, you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "1",
       "type": "Creature — Human Assassin",
       "types": [
@@ -15142,10 +13331,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15154,19 +13339,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15175,6 +13348,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}{B}{B}",
+      "mciNumber": "122",
       "multiverseid": 109758,
       "name": "Phthisis",
       "number": "122",
@@ -15189,39 +13363,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -15229,7 +13403,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "If the creature's power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
+          "text": "If the creature’s power is less than 0, use its actual value to determine the total life loss. However, if this total is 0 or less, no life is lost. For example, if Phthisis destroys a -2/3 creature, its controller would lose 1 life. If it destroys a -4/3 creature, its controller would lose no life."
         }
       ],
       "text": "Destroy target creature. Its controller loses life equal to its power plus its toughness.\nSuspend 5—{1}{B} (Rather than cast this card from your hand, you may pay {1}{B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)",
@@ -15299,10 +13473,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15311,19 +13481,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15332,6 +13490,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "123",
       "multiverseid": 116396,
       "name": "Pit Keeper",
       "number": "123",
@@ -15414,10 +13573,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15426,19 +13581,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15447,6 +13590,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "124",
       "multiverseid": 116748,
       "name": "Plague Sliver",
       "number": "124",
@@ -15460,7 +13604,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Each Sliver deals damage to its controller (not to Plague Sliver's controller)."
+          "text": "Each Sliver deals damage to its controller (not to Plague Sliver’s controller)."
         },
         {
           "date": "2013-07-01",
@@ -15542,10 +13686,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15554,19 +13694,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15575,6 +13703,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "125",
       "multiverseid": 108884,
       "name": "Premature Burial",
       "number": "125",
@@ -15650,10 +13779,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15662,19 +13787,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15683,6 +13796,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "126",
       "multiverseid": 116727,
       "name": "Psychotic Episode",
       "number": "126",
@@ -15692,7 +13806,7 @@
         "TSP"
       ],
       "rarity": "Common",
-      "text": "Target player reveals his or her hand and the top card of his or her library. You choose a card revealed this way. That player puts the chosen card on the bottom of his or her library.\nMadness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Target player reveals his or her hand and the top card of his or her library. You choose a card revealed this way. That player puts the chosen card on the bottom of his or her library.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Sorcery",
       "types": [
         "Sorcery"
@@ -15759,10 +13873,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15771,19 +13881,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15792,6 +13890,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "127",
       "multiverseid": 116741,
       "name": "Sangrophage",
       "number": "127",
@@ -15872,10 +13971,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -15884,19 +13979,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15905,6 +13988,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "128",
       "multiverseid": 116383,
       "name": "Sengir Nosferatu",
       "number": "128",
@@ -15918,11 +14002,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The Sengir Nosferatu that the Bat token's ability returns to the battlefield doesn't have to be the same one that created it, and it doesn't even have to be owned by the same player."
+          "text": "The Sengir Nosferatu that the Bat token’s ability returns to the battlefield doesn’t have to be the same one that created it, and it doesn’t even have to be owned by the same player."
         },
         {
           "date": "2007-05-01",
-          "text": "If the Nosferatu is copied (by Clone, for example) and then the copy is exiled by the first activated ability, it won't be able to come back using the second activated ability, since it's no longer named Sengir Nosferatu in the Exile zone."
+          "text": "If the Nosferatu is copied (by Clone, for example) and then the copy is exiled by the first activated ability, it won’t be able to come back using the second activated ability, since it’s no longer named Sengir Nosferatu in the Exile zone."
         }
       ],
       "subtypes": [
@@ -15996,10 +14080,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16008,19 +14088,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16029,6 +14097,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "129",
       "multiverseid": 118878,
       "name": "Skittering Monstrosity",
       "number": "129",
@@ -16109,10 +14178,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16121,19 +14186,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16142,6 +14195,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "130",
       "multiverseid": 118898,
       "name": "Skulking Knight",
       "number": "130",
@@ -16224,10 +14278,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16236,19 +14286,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16257,6 +14295,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "131",
       "multiverseid": 113531,
       "name": "Smallpox",
       "number": "131",
@@ -16342,10 +14381,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16354,19 +14389,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16375,6 +14398,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "132",
       "multiverseid": 109710,
       "name": "Strangling Soot",
       "number": "132",
@@ -16451,10 +14475,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16463,19 +14483,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16484,6 +14492,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}{B}",
+      "mciNumber": "133",
       "multiverseid": 109671,
       "name": "Stronghold Overseer",
       "number": "133",
@@ -16565,10 +14574,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16577,19 +14582,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16598,6 +14591,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "134",
       "multiverseid": 108804,
       "name": "Sudden Death",
       "number": "134",
@@ -16614,23 +14608,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget creature gets -4/-4 until end of turn.",
@@ -16699,10 +14693,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16711,19 +14701,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16732,6 +14710,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "135",
       "multiverseid": 113525,
       "name": "Sudden Spoiling",
       "number": "135",
@@ -16746,11 +14725,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling doesn't counter abilities that have already triggered or been activated. In particular, you can't cast this fast enough to stop a creature's \"At the beginning of your upkeep\" or \"When this creature enters the battlefield\" abilities from triggering."
+          "text": "Sudden Spoiling doesn’t counter abilities that have already triggered or been activated. In particular, you can’t cast this fast enough to stop a creature’s “At the beginning of your upkeep” or “When this creature enters the battlefield” abilities from triggering."
         },
         {
           "date": "2006-09-25",
-          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player's control at the time Sudden Spoiling resolves. It won't affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
+          "text": "Sudden Spoiling affects only permanents that are creatures on the battlefield under the targeted player’s control at the time Sudden Spoiling resolves. It won’t affect creatures that enter the battlefield later or noncreature permanents that later become creatures."
         },
         {
           "date": "2006-09-25",
@@ -16758,7 +14737,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a face-down creature is affected by Sudden Spoiling, it won't be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its \"When this creature turns face up\" or \"As this creature turns face up\" abilities won't work."
+          "text": "If a face-down creature is affected by Sudden Spoiling, it won’t be able to be turned face up for its morph cost. If some other effect turns it face up, it will remain a 0/2 creature with no abilities until the turn ends. Its “When this creature turns face up” or “As this creature turns face up” abilities won’t work."
         },
         {
           "date": "2013-06-07",
@@ -16766,23 +14745,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntil end of turn, creatures target player controls lose all abilities and have base power and toughness 0/2.",
@@ -16852,10 +14831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16864,19 +14839,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16885,6 +14848,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "136",
       "multiverseid": 106632,
       "name": "Tendrils of Corruption",
       "number": "136",
@@ -16906,7 +14870,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won't gain any life."
+          "text": "If the targeted creature is an illegal target by the time Tendrils of Corruption would resolve, the entire spell is countered. You won’t gain any life."
         }
       ],
       "text": "Tendrils of Corruption deals X damage to target creature and you gain X life, where X is the number of Swamps you control.",
@@ -16975,10 +14939,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -16987,19 +14947,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17008,6 +14956,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "137",
       "multiverseid": 108857,
       "name": "Traitor's Clutch",
       "number": "137",
@@ -17084,10 +15033,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17096,19 +15041,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17117,6 +15050,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "138",
       "multiverseid": 108841,
       "name": "Trespasser il-Vec",
       "number": "138",
@@ -17199,10 +15133,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17211,19 +15141,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17232,6 +15150,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "139",
       "multiverseid": 108798,
       "name": "Urborg Syphon-Mage",
       "number": "139",
@@ -17317,10 +15236,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17329,19 +15244,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17350,6 +15253,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "140",
       "multiverseid": 118900,
       "name": "Vampiric Sliver",
       "number": "140",
@@ -17367,11 +15271,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If a Sliver doesn't have this ability when it deals damage, but does have it when the damaged creature is put into a graveyard, the ability will trigger."
+          "text": "If a Sliver doesn’t have this ability when it deals damage, but does have it when the damaged creature is put into a graveyard, the ability will trigger."
         },
         {
           "date": "2006-09-25",
-          "text": "If Vampiric Sliver is put into a graveyard from the battlefield at the same time as a creature dealt damage by another Sliver, the Vampiric Sliver's ability will trigger for the other Sliver. That Sliver will get a +1/+1 counter."
+          "text": "If Vampiric Sliver is put into a graveyard from the battlefield at the same time as a creature dealt damage by another Sliver, the Vampiric Sliver’s ability will trigger for the other Sliver. That Sliver will get a +1/+1 counter."
         },
         {
           "date": "2013-07-01",
@@ -17453,10 +15357,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17465,19 +15365,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17486,6 +15374,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "141",
       "multiverseid": 111082,
       "name": "Viscid Lemures",
       "number": "141",
@@ -17566,10 +15455,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17578,19 +15463,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17599,6 +15472,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "142",
       "multiverseid": 113558,
       "name": "Ætherflame Wall",
       "number": "142",
@@ -17616,7 +15490,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If AEtherflame Wall gains shadow, it won't be able to block any creatures (not even those with shadow)."
+          "text": "If AEtherflame Wall gains shadow, it won’t be able to block any creatures (not even those with shadow)."
         }
       ],
       "subtypes": [
@@ -17691,10 +15565,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Innistrad Block",
           "legality": "Legal"
         },
@@ -17707,19 +15577,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17728,6 +15586,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "143",
       "multiverseid": 109751,
       "name": "Ancient Grudge",
       "number": "143",
@@ -17806,10 +15665,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17818,19 +15673,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17839,6 +15682,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "144",
       "multiverseid": 109762,
       "name": "Barbed Shocker",
       "number": "144",
@@ -17926,10 +15770,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -17938,19 +15778,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17959,6 +15787,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "145",
       "multiverseid": 118883,
       "name": "Basalt Gargoyle",
       "number": "145",
@@ -18040,10 +15869,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18052,19 +15877,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18073,6 +15886,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "146",
       "multiverseid": 108799,
       "name": "Blazing Blade Askari",
       "number": "146",
@@ -18154,10 +15968,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18166,19 +15976,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18187,6 +15985,7 @@
         }
       ],
       "manaCost": "{6}{R}{R}",
+      "mciNumber": "147",
       "multiverseid": 111041,
       "name": "Bogardan Hellkite",
       "number": "147",
@@ -18278,10 +16077,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18290,19 +16085,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18311,6 +16094,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "148",
       "multiverseid": 108901,
       "name": "Bogardan Rager",
       "number": "148",
@@ -18394,10 +16178,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18406,19 +16186,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18427,6 +16195,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "149",
       "multiverseid": 109697,
       "name": "Bonesplitter Sliver",
       "number": "149",
@@ -18518,10 +16287,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18530,19 +16295,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18551,6 +16304,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "150",
       "multiverseid": 113618,
       "name": "Coal Stoker",
       "number": "150",
@@ -18565,11 +16319,11 @@
       "rulings": [
         {
           "date": "2011-01-25",
-          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
         },
         {
           "date": "2013-09-20",
-          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
+          "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy’s “enters-the-battlefield” ability will still trigger as long as you cast that creature spell from your hand."
         }
       ],
       "subtypes": [
@@ -18642,10 +16396,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18654,19 +16404,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18675,6 +16413,7 @@
         }
       ],
       "manaCost": "{X}{X}{R}",
+      "mciNumber": "151",
       "multiverseid": 114909,
       "name": "Conflagrate",
       "number": "151",
@@ -18761,10 +16500,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18773,19 +16508,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18794,6 +16517,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "152",
       "multiverseid": 109735,
       "name": "Empty the Warrens",
       "number": "152",
@@ -18807,15 +16531,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -18888,10 +16612,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -18900,19 +16620,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18921,6 +16629,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "153",
       "multiverseid": 111064,
       "name": "Firemaw Kavu",
       "number": "153",
@@ -19002,10 +16711,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19014,19 +16719,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19035,6 +16728,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "154",
       "multiverseid": 108870,
       "name": "Flamecore Elemental",
       "number": "154",
@@ -19116,10 +16810,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19128,19 +16818,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19149,6 +16827,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "155",
       "multiverseid": 106653,
       "name": "Flowstone Channeler",
       "number": "155",
@@ -19230,10 +16909,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19242,19 +16917,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19263,6 +16926,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "156",
       "multiverseid": 126289,
       "name": "Fortune Thief",
       "number": "156",
@@ -19276,11 +16940,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The first ability applies only if your life total is being reduced by damage. Other effects or costs (such as \"lose 1 life\" or \"pay 1 life\") can reduce your life total below 1 as normal."
+          "text": "The first ability applies only if your life total is being reduced by damage. Other effects or costs (such as “lose 1 life” or “pay 1 life\") can reduce your life total below 1 as normal."
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect asks you to pay life, you can't pay more life than you have."
+          "text": "If an effect asks you to pay life, you can’t pay more life than you have."
         },
         {
           "date": "2006-09-25",
@@ -19288,11 +16952,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The ability doesn't change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
+          "text": "The ability doesn’t change how much damage is dealt; it just changes how much life that damage makes you lose. An effect such as Spirit Link will see the full amount of damage being dealt."
         },
         {
           "date": "2006-09-25",
-          "text": "Thief won't prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
+          "text": "Thief won’t prevent you from losing the game if your life total is 0 or less or some other effect causes you to lose the game."
         }
       ],
       "subtypes": [
@@ -19367,10 +17031,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19379,19 +17039,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19400,6 +17048,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "157",
       "multiverseid": 109722,
       "name": "Fury Sliver",
       "number": "157",
@@ -19491,10 +17140,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19503,19 +17148,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19524,6 +17157,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "158",
       "multiverseid": 108838,
       "name": "Ghitu Firebreathing",
       "number": "158",
@@ -19536,7 +17170,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If you return Ghitu Firebreathing to its owner's hand while the +1/+0 ability is on the stack, that ability will still give the creature that was last enchanted by Ghitu Firebreathing +1/+0."
+          "text": "If you return Ghitu Firebreathing to its owner’s hand while the +1/+0 ability is on the stack, that ability will still give the creature that was last enchanted by Ghitu Firebreathing +1/+0."
         }
       ],
       "subtypes": [
@@ -19609,10 +17243,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19621,19 +17251,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19642,6 +17260,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "159",
       "multiverseid": 124758,
       "name": "Goblin Skycutter",
       "number": "159",
@@ -19724,10 +17343,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19736,19 +17351,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19757,6 +17360,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "160",
       "multiverseid": 118882,
       "name": "Grapeshot",
       "number": "160",
@@ -19770,15 +17374,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -19855,10 +17459,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -19867,19 +17467,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19888,6 +17476,7 @@
         }
       ],
       "manaCost": "{9}{R}",
+      "mciNumber": "161",
       "multiverseid": 111048,
       "name": "Greater Gargadon",
       "number": "161",
@@ -19902,39 +17491,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -20012,10 +17601,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20024,19 +17609,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20045,6 +17618,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "162",
       "multiverseid": 108905,
       "name": "Ground Rift",
       "number": "162",
@@ -20057,15 +17631,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -20143,10 +17717,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20155,19 +17725,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20176,6 +17734,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "163",
       "multiverseid": 114912,
       "name": "Ib Halfheart, Goblin Tactician",
       "number": "163",
@@ -20191,7 +17750,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If you don't actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
+          "text": "If you don’t actually sacrifice the Goblin (because it was removed from the battlefield before the ability resolved, for example), no damage is dealt."
         }
       ],
       "subtypes": [
@@ -20268,10 +17827,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20280,19 +17835,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20301,6 +17844,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "164",
       "multiverseid": 109756,
       "name": "Ignite Memories",
       "number": "164",
@@ -20313,15 +17857,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -20399,10 +17943,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20411,19 +17951,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20432,6 +17960,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "165",
       "multiverseid": 116723,
       "name": "Ironclaw Buzzardiers",
       "number": "165",
@@ -20445,7 +17974,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "\"Can't block\" abilities apply only as blockers are declared. After Ironclaw Buzzardiers blocks, increasing the blocked creature's power won't make it become unblocked."
+          "text": "“Can’t block” abilities apply only as blockers are declared. After Ironclaw Buzzardiers blocks, increasing the blocked creature’s power won’t make it become unblocked."
         }
       ],
       "subtypes": [
@@ -20519,10 +18048,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20531,19 +18056,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20552,6 +18065,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "166",
       "multiverseid": 109752,
       "name": "Jaya Ballard, Task Mage",
       "number": "166",
@@ -20638,10 +18152,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20650,19 +18160,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20671,6 +18169,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "167",
       "multiverseid": 108891,
       "name": "Keldon Halberdier",
       "number": "167",
@@ -20684,39 +18183,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -20820,6 +18319,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "168",
       "multiverseid": 113567,
       "name": "Lightning Axe",
       "number": "168",
@@ -20833,7 +18333,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "This has an additional cost with an option. Essentially, the card's cost to cast is either {5}{R} or {R} and a discard. But its mana cost is always {R} and its converted mana cost is always 1."
+          "text": "This has an additional cost with an option. Essentially, the card’s cost to cast is either {5}{R} or {R} and a discard. But its mana cost is always {R} and its converted mana cost is always 1."
+        },
+        {
+          "date": "2016-04-08",
+          "text": "The converted mana cost of Lightning Axe is 1, independent of which additional cost you paid."
         }
       ],
       "text": "As an additional cost to cast Lightning Axe, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
@@ -20902,10 +18406,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -20914,19 +18414,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20935,6 +18423,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "169",
       "multiverseid": 126279,
       "name": "Magus of the Scroll",
       "number": "169",
@@ -21016,10 +18505,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21028,19 +18513,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21049,6 +18522,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "170",
       "multiverseid": 116739,
       "name": "Mogg War Marshal",
       "number": "170",
@@ -21134,10 +18608,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21146,19 +18616,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21167,6 +18625,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "171",
       "multiverseid": 113512,
       "name": "Norin the Wary",
       "number": "171",
@@ -21258,10 +18717,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21270,19 +18725,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21291,6 +18734,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "172",
       "multiverseid": 114902,
       "name": "Orcish Cannonade",
       "number": "172",
@@ -21368,10 +18812,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21380,19 +18820,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21401,6 +18829,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "173",
       "multiverseid": 109686,
       "name": "Pardic Dragon",
       "number": "173",
@@ -21415,39 +18844,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -21524,10 +18953,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21536,19 +18961,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21557,6 +18970,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "174",
       "multiverseid": 108926,
       "name": "Plunder",
       "number": "174",
@@ -21569,39 +18983,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -21675,10 +19089,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21687,19 +19097,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21708,6 +19106,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "175",
       "multiverseid": 109729,
       "name": "Reiterate",
       "number": "175",
@@ -21783,10 +19182,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21795,19 +19190,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21816,6 +19199,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "176",
       "multiverseid": 108915,
       "name": "Rift Bolt",
       "number": "176",
@@ -21830,39 +19214,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -21937,10 +19321,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -21949,19 +19329,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21970,6 +19338,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "177",
       "multiverseid": 118917,
       "name": "Sedge Sliver",
       "number": "177",
@@ -22060,10 +19429,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22072,19 +19437,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22093,6 +19446,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "178",
       "multiverseid": 113611,
       "name": "Subterranean Shambler",
       "number": "178",
@@ -22174,10 +19528,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22186,19 +19536,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22207,6 +19545,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "179",
       "multiverseid": 114911,
       "name": "Sudden Shock",
       "number": "179",
@@ -22225,23 +19564,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nSudden Shock deals 2 damage to target creature or player.",
@@ -22311,10 +19650,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22323,19 +19658,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22344,6 +19667,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "180",
       "multiverseid": 109685,
       "name": "Sulfurous Blast",
       "number": "180",
@@ -22421,10 +19745,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22433,19 +19753,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22454,6 +19762,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "181",
       "multiverseid": 113616,
       "name": "Tectonic Fiend",
       "number": "181",
@@ -22535,10 +19844,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22547,19 +19852,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22568,6 +19861,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "182",
       "multiverseid": 109703,
       "name": "Thick-Skinned Goblin",
       "number": "182",
@@ -22656,10 +19950,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22668,19 +19958,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22689,6 +19967,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "183",
       "multiverseid": 108851,
       "name": "Two-Headed Sliver",
       "number": "183",
@@ -22780,10 +20059,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22792,19 +20067,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22813,6 +20076,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "184",
       "multiverseid": 126280,
       "name": "Undying Rage",
       "number": "184",
@@ -22893,10 +20157,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -22905,19 +20165,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22926,6 +20174,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "185",
       "multiverseid": 111069,
       "name": "Viashino Bladescout",
       "number": "185",
@@ -23008,10 +20257,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23020,19 +20265,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23041,6 +20274,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "186",
       "multiverseid": 121206,
       "name": "Volcanic Awakening",
       "number": "186",
@@ -23053,15 +20287,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -23137,10 +20371,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23149,19 +20379,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23169,6 +20387,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "187",
       "multiverseid": 113528,
       "name": "Wheel of Fate",
       "number": "187",
@@ -23181,47 +20400,47 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind's Desire."
+          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
+          "text": "This has no mana cost, which means it can’t be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -23229,7 +20448,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Suspend 4—{1}{R} (Rather than cast this card from your hand, pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nEach player discards his or her hand, then draws seven cards.",
@@ -23299,10 +20518,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23311,19 +20526,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23332,6 +20535,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "188",
       "multiverseid": 118870,
       "name": "Word of Seizing",
       "number": "188",
@@ -23350,23 +20554,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nUntap target permanent and gain control of it until end of turn. It gains haste until end of turn.",
@@ -23435,10 +20639,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23447,19 +20647,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23468,6 +20656,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "189",
       "multiverseid": 108852,
       "name": "Æther Web",
       "number": "189",
@@ -23484,7 +20673,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If the enchanted creature has shadow, it won't be able to block any creatures (not even those with shadow)."
+          "text": "If the enchanted creature has shadow, it won’t be able to block any creatures (not even those with shadow)."
         }
       ],
       "subtypes": [
@@ -23557,10 +20746,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23569,19 +20754,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23590,6 +20763,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "190",
       "multiverseid": 114905,
       "name": "Ashcoat Bear",
       "number": "190",
@@ -23670,10 +20844,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23682,19 +20852,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23703,6 +20861,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "191",
       "multiverseid": 116740,
       "name": "Aspect of Mongoose",
       "number": "191",
@@ -23782,10 +20941,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23794,19 +20949,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23815,6 +20958,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "192",
       "multiverseid": 118925,
       "name": "Chameleon Blur",
       "number": "192",
@@ -23890,10 +21034,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -23902,19 +21042,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -23923,6 +21051,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "193",
       "multiverseid": 108807,
       "name": "Durkwood Baloth",
       "number": "193",
@@ -23937,39 +21066,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -24047,10 +21176,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24059,19 +21184,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24080,6 +21193,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "194",
       "multiverseid": 118893,
       "name": "Durkwood Tracker",
       "number": "194",
@@ -24093,7 +21207,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "If Durkwood Tracker has left the battlefield before the ability resolves, the ability doesn't do anything. If the targeted creature has left the battlefield before the ability resolves, the ability is countered."
+          "text": "If Durkwood Tracker has left the battlefield before the ability resolves, the ability doesn’t do anything. If the targeted creature has left the battlefield before the ability resolves, the ability is countered."
         }
       ],
       "subtypes": [
@@ -24167,10 +21281,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24179,19 +21289,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24200,6 +21298,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "195",
       "multiverseid": 118881,
       "name": "Fungus Sliver",
       "number": "195",
@@ -24293,10 +21392,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24305,19 +21400,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24326,6 +21409,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "196",
       "multiverseid": 118922,
       "name": "Gemhide Sliver",
       "number": "196",
@@ -24418,10 +21502,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24430,19 +21510,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24451,6 +21519,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "197",
       "multiverseid": 113537,
       "name": "Glass Asp",
       "number": "197",
@@ -24464,7 +21533,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "After Glass Asp's triggered ability resolves, the affected player has the ability to perform a special action of paying {2}. This action may be performed any time the player has priority, and it doesn't use the stack. It may be performed only once. Once that player's next draw step begins, the player no longer has the ability to perform this action. If the player performed the action, the delayed \"lose 2 life\" triggered ability won't trigger. Otherwise, it will."
+          "text": "After Glass Asp’s triggered ability resolves, the affected player has the ability to perform a special action of paying {2}. This action may be performed any time the player has priority, and it doesn’t use the stack. It may be performed only once. Once that player’s next draw step begins, the player no longer has the ability to perform this action. If the player performed the action, the delayed “lose 2 life” triggered ability won’t trigger. Otherwise, it will."
         }
       ],
       "subtypes": [
@@ -24538,10 +21607,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24550,19 +21615,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24571,6 +21624,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "198",
       "multiverseid": 108830,
       "name": "Greenseeker",
       "number": "198",
@@ -24653,10 +21707,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24665,19 +21715,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24686,6 +21724,7 @@
         }
       ],
       "manaCost": "{6}{G}",
+      "mciNumber": "199",
       "multiverseid": 108808,
       "name": "Havenwood Wurm",
       "number": "199",
@@ -24767,10 +21806,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24779,19 +21814,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24800,6 +21823,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "200",
       "multiverseid": 118873,
       "name": "Herd Gnarr",
       "number": "200",
@@ -24879,10 +21903,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -24891,19 +21911,7 @@
           "legality": "Banned"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -24911,6 +21919,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "201",
       "multiverseid": 113533,
       "name": "Hypergenesis",
       "number": "201",
@@ -24923,15 +21932,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn't end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn’t end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind's Desire."
+          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
+          "text": "This has no mana cost, which means it can’t be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
         },
         {
           "date": "2006-10-15",
@@ -24939,39 +21948,39 @@
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -24979,7 +21988,7 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can't be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
+          "text": "Although originally printed with a characteristic-defining ability that defined its color, this card now has a color indicator. This color indicator can’t be affected by text-changing effects (such as the one created by Crystal Spray), although color-changing effects can still overwrite it."
         }
       ],
       "text": "Suspend 3—{1}{G}{G} (Rather than cast this card from your hand, pay {1}{G}{G} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, cast it without paying its mana cost.)\nStarting with you, each player may put an artifact, creature, enchantment, or land card from his or her hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
@@ -25049,10 +22058,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25061,19 +22066,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25082,6 +22075,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "202",
       "multiverseid": 126274,
       "name": "Krosan Grip",
       "number": "202",
@@ -25102,23 +22096,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nDestroy target artifact or enchantment.",
@@ -25188,10 +22182,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25200,19 +22190,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25221,6 +22199,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "203",
       "multiverseid": 126273,
       "name": "Magus of the Candelabra",
       "number": "203",
@@ -25303,10 +22282,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25315,19 +22290,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25336,6 +22299,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "204",
       "multiverseid": 109763,
       "name": "Might of Old Krosa",
       "number": "204",
@@ -25412,10 +22376,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25424,19 +22384,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25445,6 +22393,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "205",
       "multiverseid": 111042,
       "name": "Might Sliver",
       "number": "205",
@@ -25537,10 +22486,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25549,19 +22494,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25570,6 +22503,7 @@
         }
       ],
       "manaCost": "{X}{G}",
+      "mciNumber": "206",
       "multiverseid": 114914,
       "name": "Molder",
       "number": "206",
@@ -25646,10 +22580,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25658,19 +22588,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25679,6 +22597,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "207",
       "multiverseid": 118888,
       "name": "Mwonvuli Acid-Moss",
       "number": "207",
@@ -25754,10 +22673,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25766,19 +22681,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25787,6 +22690,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "208",
       "multiverseid": 109726,
       "name": "Nantuko Shaman",
       "number": "208",
@@ -25801,39 +22705,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -25912,10 +22816,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -25924,19 +22824,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -25945,6 +22833,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "209",
       "multiverseid": 111083,
       "name": "Pendelhaven Elder",
       "number": "209",
@@ -26027,10 +22916,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26039,19 +22924,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26060,6 +22933,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "210",
       "multiverseid": 118899,
       "name": "Penumbra Spider",
       "number": "210",
@@ -26144,10 +23018,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26156,19 +23026,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26177,6 +23035,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "211",
       "multiverseid": 118868,
       "name": "Phantom Wurm",
       "number": "211",
@@ -26259,10 +23118,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26271,19 +23126,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26292,6 +23135,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "212",
       "multiverseid": 110508,
       "name": "Primal Forcemage",
       "number": "212",
@@ -26373,10 +23217,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26385,19 +23225,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26406,6 +23234,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "213",
       "multiverseid": 106643,
       "name": "Savage Thallid",
       "number": "213",
@@ -26487,10 +23316,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26499,19 +23324,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26520,6 +23333,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "214",
       "multiverseid": 110524,
       "name": "Scarwood Treefolk",
       "number": "214",
@@ -26600,10 +23414,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26612,19 +23422,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26633,6 +23431,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "215",
       "multiverseid": 118924,
       "name": "Scryb Ranger",
       "number": "215",
@@ -26713,10 +23512,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26725,19 +23520,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26746,6 +23529,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "216",
       "multiverseid": 108802,
       "name": "Search for Tomorrow",
       "number": "216",
@@ -26760,39 +23544,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -26866,10 +23650,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26878,19 +23658,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -26899,6 +23667,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "217",
       "multiverseid": 118871,
       "name": "Spectral Force",
       "number": "217",
@@ -26912,7 +23681,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "”Your next untap…” refers to the player who controls Spectral Force when the triggered ability resolves. That means if it's temporarily stolen (such as with Word of Seizing) and attacked with, it will untap in its previous controller's untap step."
+          "text": "”Your next untap…” refers to the player who controls Spectral Force when the triggered ability resolves. That means if it’s temporarily stolen (such as with Word of Seizing) and attacked with, it will untap in its previous controller’s untap step."
         }
       ],
       "subtypes": [
@@ -26986,10 +23755,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -26998,19 +23763,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27019,6 +23772,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "218",
       "multiverseid": 109689,
       "name": "Spike Tiller",
       "number": "218",
@@ -27032,7 +23786,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -27106,10 +23860,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27118,19 +23868,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27139,6 +23877,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "219",
       "multiverseid": 111073,
       "name": "Spinneret Sliver",
       "number": "219",
@@ -27229,10 +23968,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27241,19 +23976,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27262,6 +23985,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "220",
       "multiverseid": 111068,
       "name": "Sporesower Thallid",
       "number": "220",
@@ -27276,7 +24000,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Sporesower Thallid's triggered ability will put a spore counter on each Fungus creature you control, even if that Fungus doesn't have any abilities that makes use of them."
+          "text": "Sporesower Thallid’s triggered ability will put a spore counter on each Fungus creature you control, even if that Fungus doesn’t have any abilities that makes use of them."
         }
       ],
       "subtypes": [
@@ -27350,10 +24074,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27362,19 +24082,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27383,6 +24091,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "221",
       "multiverseid": 122079,
       "name": "Sprout",
       "number": "221",
@@ -27459,10 +24168,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27471,19 +24176,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27492,6 +24185,7 @@
         }
       ],
       "manaCost": "{X}{G}{G}",
+      "mciNumber": "222",
       "multiverseid": 109702,
       "name": "Squall Line",
       "number": "222",
@@ -27568,10 +24262,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27580,19 +24270,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27601,6 +24279,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "223",
       "multiverseid": 118890,
       "name": "Stonewood Invocation",
       "number": "223",
@@ -27617,23 +24296,23 @@
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from activating mana abilities."
+          "text": "Split second doesn’t prevent players from activating mana abilities."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
+          "text": "Split second doesn’t prevent triggered abilities from triggering. If one does, its controller puts it on the stack and chooses targets for it, if any. Those abilities will resolve as normal."
         },
         {
           "date": "2013-06-07",
-          "text": "Split second doesn't prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
+          "text": "Split second doesn’t prevent players from performing special actions. Notably, players may turn face-down creatures face up while a spell with split second is on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "Casting a spell with split second won't affect spells and abilities that are already on the stack."
+          "text": "Casting a spell with split second won’t affect spells and abilities that are already on the stack."
         },
         {
           "date": "2013-06-07",
-          "text": "If the resolution of a triggered ability involves casting a spell, that spell can't be cast if a spell with split second is on the stack."
+          "text": "If the resolution of a triggered ability involves casting a spell, that spell can’t be cast if a spell with split second is on the stack."
         }
       ],
       "text": "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nTarget creature gets +5/+5 and gains shroud until end of turn. (It can't be the target of spells or abilities.)",
@@ -27703,10 +24382,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27715,19 +24390,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27736,6 +24399,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "224",
       "multiverseid": 116730,
       "name": "Strength in Numbers",
       "number": "224",
@@ -27817,10 +24481,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27829,19 +24489,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27850,6 +24498,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "225",
       "multiverseid": 116381,
       "name": "Thallid Germinator",
       "number": "225",
@@ -27931,10 +24580,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -27943,19 +24588,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -27964,6 +24597,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "226",
       "multiverseid": 116731,
       "name": "Thallid Shell-Dweller",
       "number": "226",
@@ -28047,10 +24681,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28059,19 +24689,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28080,6 +24698,7 @@
         }
       ],
       "manaCost": "{G}{G}",
+      "mciNumber": "227",
       "multiverseid": 116737,
       "name": "Thelon of Havenwood",
       "number": "227",
@@ -28170,10 +24789,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28182,19 +24797,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28203,6 +24806,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "228",
       "multiverseid": 126275,
       "name": "Thelonite Hermit",
       "number": "228",
@@ -28287,10 +24891,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28299,19 +24899,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28320,6 +24908,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "229",
       "multiverseid": 109675,
       "name": "Thrill of the Hunt",
       "number": "229",
@@ -28396,10 +24985,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28408,19 +24993,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28429,6 +25002,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "230",
       "multiverseid": 116726,
       "name": "Tromp the Domains",
       "number": "230",
@@ -28442,7 +25016,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "The creatures get trample once; they don't get trample for each basic land type."
+          "text": "The creatures get trample once; they don’t get trample for each basic land type."
         },
         {
           "date": "2006-09-25",
@@ -28462,7 +25036,7 @@
         },
         {
           "date": "2009-02-01",
-          "text": "A number of nonbasic lands have basic land types. Domain abilities don't count the number of lands you control -- they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you'll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
+          "text": "A number of nonbasic lands have basic land types. Domain abilities don’t count the number of lands you control -- they count the number of basic land types among lands you control, even if that means checking the same land twice. For example, if you control a Tundra, an Overgrown Tomb, and a Madblind Mountain, you’ll have a Plains, Island, Swamp, Mountain, and Forest among the lands you control. Your domain abilities will be maxed out."
         }
       ],
       "text": "Domain — Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
@@ -28532,10 +25106,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28544,19 +25114,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28565,6 +25123,7 @@
         }
       ],
       "manaCost": "{G}{G}{G}",
+      "mciNumber": "231",
       "multiverseid": 113579,
       "name": "Unyaro Bees",
       "number": "231",
@@ -28645,10 +25204,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28657,19 +25212,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28678,6 +25221,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "232",
       "multiverseid": 109766,
       "name": "Verdant Embrace",
       "number": "232",
@@ -28763,10 +25307,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28775,19 +25315,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28796,6 +25324,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "233",
       "multiverseid": 113583,
       "name": "Wormwood Dryad",
       "number": "233",
@@ -28876,10 +25405,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28888,19 +25413,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -28909,6 +25422,7 @@
         }
       ],
       "manaCost": "{X}{G}",
+      "mciNumber": "234",
       "multiverseid": 114917,
       "name": "Wurmcalling",
       "number": "234",
@@ -28985,10 +25499,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -28997,19 +25507,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29018,6 +25516,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "235",
       "multiverseid": 118884,
       "name": "Yavimaya Dryad",
       "number": "235",
@@ -29032,7 +25531,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "You may target yourself with Yavimaya Dryad's ability."
+          "text": "You may target yourself with Yavimaya Dryad’s ability."
         }
       ],
       "subtypes": [
@@ -29107,10 +25606,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29119,19 +25614,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29140,6 +25623,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "236",
       "multiverseid": 109668,
       "name": "Dementia Sliver",
       "number": "236",
@@ -29232,10 +25716,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29244,19 +25724,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29265,6 +25733,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "237",
       "multiverseid": 113541,
       "name": "Dralnu, Lich Lord",
       "number": "237",
@@ -29282,7 +25751,7 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If you don't control enough permanents, sacrifice all permanents you control."
+          "text": "If you don’t control enough permanents, sacrifice all permanents you control."
         }
       ],
       "subtypes": [
@@ -29362,10 +25831,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29374,19 +25839,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29395,6 +25848,7 @@
         }
       ],
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "238",
       "multiverseid": 109727,
       "name": "Firewake Sliver",
       "number": "238",
@@ -29488,10 +25942,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29500,19 +25950,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29521,6 +25959,7 @@
         }
       ],
       "manaCost": "{B}{R}",
+      "mciNumber": "239",
       "multiverseid": 109717,
       "name": "Ghostflame Sliver",
       "number": "239",
@@ -29614,10 +26053,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29626,19 +26061,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29647,6 +26070,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "240",
       "multiverseid": 109706,
       "name": "Harmonic Sliver",
       "number": "240",
@@ -29747,10 +26171,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29759,19 +26179,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29780,6 +26188,7 @@
         }
       ],
       "manaCost": "{5}{W}{U}",
+      "mciNumber": "241",
       "multiverseid": 114903,
       "name": "Ith, High Arcanist",
       "number": "241",
@@ -29793,39 +26202,39 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -29913,10 +26322,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -29925,19 +26330,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -29946,6 +26339,7 @@
         }
       ],
       "manaCost": "{5}{B}{R}",
+      "mciNumber": "242",
       "multiverseid": 113536,
       "name": "Kaervek the Merciless",
       "number": "242",
@@ -30036,10 +26430,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30048,19 +26438,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30069,6 +26447,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}{R}",
+      "mciNumber": "243",
       "multiverseid": 113539,
       "name": "Mishra, Artificer Prodigy",
       "number": "243",
@@ -30156,10 +26535,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30168,19 +26543,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30189,6 +26552,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "244",
       "multiverseid": 109711,
       "name": "Opaline Sliver",
       "number": "244",
@@ -30282,10 +26646,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30294,19 +26654,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30315,6 +26663,7 @@
         }
       ],
       "manaCost": "{G}{W}",
+      "mciNumber": "245",
       "multiverseid": 113540,
       "name": "Saffi Eriksdotter",
       "number": "245",
@@ -30332,11 +26681,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "The creature is returned to the battlefield under your control if it's put into *your* graveyard from the battlefield. It doesn't matter who controlled it when Saffi targeted it."
+          "text": "The creature is returned to the battlefield under your control if it’s put into *your* graveyard from the battlefield. It doesn’t matter who controlled it when Saffi targeted it."
         },
         {
           "date": "2006-09-25",
-          "text": "Saffi can target itself, but it won't return itself to the battlefield. It will already be in the graveyard when the ability resolves, so the ability will be countered."
+          "text": "Saffi can target itself, but it won’t return itself to the battlefield. It will already be in the graveyard when the ability resolves, so the ability will be countered."
         }
       ],
       "subtypes": [
@@ -30422,10 +26771,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30434,19 +26779,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30455,6 +26788,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}{R}{G}",
+      "mciNumber": "246",
       "multiverseid": 116745,
       "name": "Scion of the Ur-Dragon",
       "number": "246",
@@ -30552,10 +26886,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30564,19 +26894,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30585,6 +26903,7 @@
         }
       ],
       "manaCost": "{3}{R}{G}",
+      "mciNumber": "247",
       "multiverseid": 118915,
       "name": "Stonebrow, Krosan Hero",
       "number": "247",
@@ -30664,10 +26983,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30676,19 +26991,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30697,6 +27000,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "248",
       "multiverseid": 114916,
       "name": "Assembly-Worker",
       "number": "248",
@@ -30780,10 +27084,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30792,19 +27092,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30813,6 +27101,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "249",
       "multiverseid": 118876,
       "name": "Brass Gnat",
       "number": "249",
@@ -30889,10 +27178,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -30901,19 +27186,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -30922,6 +27195,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "250",
       "multiverseid": 113529,
       "name": "Candles of Leng",
       "number": "250",
@@ -30934,7 +27208,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Unless something weird happens, the card that's drawn will be the card that was revealed."
+          "text": "Unless something weird happens, the card that’s drawn will be the card that was revealed."
         }
       ],
       "text": "{4}, {T}: Reveal the top card of your library. If it has the same name as a card in your graveyard, put it into your graveyard. Otherwise, draw a card.",
@@ -30998,10 +27272,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31010,19 +27280,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31031,6 +27289,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "251",
       "multiverseid": 118891,
       "name": "Chromatic Star",
       "number": "251",
@@ -31104,10 +27363,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31116,19 +27371,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31137,6 +27380,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "252",
       "multiverseid": 106630,
       "name": "Chronatog Totem",
       "number": "252",
@@ -31149,7 +27393,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {U} to your mana pool.\n{1}{U}: Chronatog Totem becomes a 1/2 blue Atog artifact creature until end of turn.\n{0}: Chronatog Totem gets +3/+3 until end of turn. You skip your next turn. Activate this ability only once each turn and only if Chronatog Totem is a creature.",
@@ -31212,10 +27456,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31224,19 +27464,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31245,6 +27473,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "253",
       "multiverseid": 113530,
       "name": "Clockwork Hydra",
       "number": "253",
@@ -31324,10 +27553,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31336,19 +27561,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31357,6 +27570,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "254",
       "multiverseid": 108904,
       "name": "Foriysian Totem",
       "number": "254",
@@ -31373,14 +27587,14 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If an effect says Foriysian Totem can't block, then it can't block any creatures."
+          "text": "If an effect says Foriysian Totem can’t block, then it can’t block any creatures."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
-      "text": "{T}: Add {R} to your mana pool.\n{4}{R}: Foriysian Totem becomes a 4/4 red Giant artifact creature with trample until end of turn.\nAs long as Foriysian Totem is a creature, it can block an additional creature.",
+      "text": "{T}: Add {R} to your mana pool.\n{4}{R}: Foriysian Totem becomes a 4/4 red Giant artifact creature with trample until end of turn.\nAs long as Foriysian Totem is a creature, it can block an additional creature each combat.",
       "type": "Artifact",
       "types": [
         "Artifact"
@@ -31440,10 +27654,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31452,19 +27662,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31473,6 +27671,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "255",
       "multiverseid": 124220,
       "name": "Gauntlet of Power",
       "number": "255",
@@ -31543,10 +27742,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31555,19 +27750,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31576,6 +27759,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "256",
       "multiverseid": 116387,
       "name": "Hivestone",
       "number": "256",
@@ -31592,7 +27776,7 @@
         },
         {
           "date": "2006-10-15",
-          "text": "Turns only your creatures on the battlefield, not in other zones, into Slivers. It won't allow you to have Root Sliver on the battlefield and make your Grizzly Bears uncounterable, for example."
+          "text": "Turns only your creatures on the battlefield, not in other zones, into Slivers. It won’t allow you to have Root Sliver on the battlefield and make your Grizzly Bears uncounterable, for example."
         }
       ],
       "text": "Creatures you control are Slivers in addition to their other creature types.",
@@ -31655,10 +27839,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31667,19 +27847,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31688,6 +27856,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "257",
       "multiverseid": 118879,
       "name": "Jhoira's Timebug",
       "number": "257",
@@ -31764,10 +27933,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31776,19 +27941,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31797,6 +27950,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "258",
       "multiverseid": 113513,
       "name": "Locket of Yesterdays",
       "number": "258",
@@ -31809,15 +27963,15 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Locket of Yesterdays reduces only the amount of mana you need to pay to cast a spell. The spell's mana cost and converted mana cost are not affected."
+          "text": "Locket of Yesterdays reduces only the amount of mana you need to pay to cast a spell. The spell’s mana cost and converted mana cost are not affected."
         },
         {
           "date": "2006-09-25",
-          "text": "Colored costs can't be reduced by this effect. For example, a spell that costs {2}{R} can't be reduced by more than {2}."
+          "text": "Colored costs can’t be reduced by this effect. For example, a spell that costs {2}{R} can’t be reduced by more than {2}."
         },
         {
           "date": "2006-09-25",
-          "text": "The spell being cast doesn't reduce its own cost, even if you're casting it from a graveyard. At the time the cost is reduced, the spell is on the stack."
+          "text": "The spell being cast doesn’t reduce its own cost, even if you’re casting it from a graveyard. At the time the cost is reduced, the spell is on the stack."
         }
       ],
       "text": "Spells you cast cost {1} less to cast for each card with the same name as that spell in your graveyard.",
@@ -31879,10 +28033,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -31891,19 +28041,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -31911,6 +28049,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "259",
       "multiverseid": 114904,
       "name": "Lotus Bloom",
       "number": "259",
@@ -31925,47 +28064,47 @@
       "rulings": [
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind's Desire."
+          "text": "This has no mana cost, which means it can’t normally be cast as a spell. You could, however, cast it via some alternate means, like with Fist of Suns or Mind’s Desire."
         },
         {
           "date": "2006-10-15",
-          "text": "This has no mana cost, which means it can't be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
+          "text": "This has no mana cost, which means it can’t be cast with the Replicate ability of Djinn Illuminatus or by somehow giving it Flashback."
         },
         {
           "date": "2013-06-07",
-          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage's effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
+          "text": "You can exile a card in your hand using suspend any time you could cast that card. Consider its card type, any effect that affects when you could cast it (such as flash) and any other effects that could stop you from casting it (such as Meddling Mage’s effect) to determine if and when you can do this. Whether or not you could actually complete all steps in casting the card is irrelevant. For example, you can exile a card with suspend that has no mana cost or requires a target even if no legal targets are available at that time."
         },
         {
           "date": "2013-06-07",
-          "text": "Exiling a card with suspend isn't casting that card. This action doesn't use the stack and can't be responded to."
+          "text": "Exiling a card with suspend isn’t casting that card. This action doesn’t use the stack and can’t be responded to."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it's exiled."
+          "text": "If the spell requires any targets, those targets are chosen when the spell is finally cast, not when it’s exiled."
         },
         {
           "date": "2013-06-07",
-          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card's owner's next upkeep."
+          "text": "If the first triggered ability of suspend (the one that removes time counters) is countered, no time counter is removed. The ability will trigger again during the card’s owner’s next upkeep."
         },
         {
           "date": "2013-06-07",
-          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn't matter why the last time counter was removed or what effect removed it."
+          "text": "When the last time counter is removed, the second triggered ability of suspend will trigger. It doesn’t matter why the last time counter was removed or what effect removed it."
         },
         {
           "date": "2013-06-07",
-          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can't be cast. It remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If the second triggered ability of suspend (the one that lets you cast the card) is countered, the card can’t be cast. It remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card's type are ignored."
+          "text": "As the second triggered ability resolves, you must cast the card if able. Timing restrictions based on the card’s type are ignored."
         },
         {
           "date": "2013-06-07",
-          "text": "If you can't cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it's no longer suspended."
+          "text": "If you can’t cast the card, perhaps because there are no legal targets available, it remains exiled with no time counters on it, and it’s no longer suspended."
         },
         {
           "date": "2013-06-07",
-          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there's enough mana in your mana pool at the time you cast the spell. You aren't forced to activate any mana abilities, although you may do so if you wish."
+          "text": "If the spell has any mandatory additional costs, you must pay those if able. However, if an additional cost includes a mana payment, you are forced to pay that cost only if there’s enough mana in your mana pool at the time you cast the spell. You aren’t forced to activate any mana abilities, although you may do so if you wish."
         },
         {
           "date": "2013-06-07",
@@ -32033,10 +28172,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32045,19 +28180,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32066,6 +28189,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "260",
       "multiverseid": 122091,
       "name": "Paradise Plume",
       "number": "260",
@@ -32138,10 +28262,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32150,19 +28270,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32171,6 +28279,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "261",
       "multiverseid": 108822,
       "name": "Phyrexian Totem",
       "number": "261",
@@ -32184,11 +28293,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "When damage is dealt to Phyrexian Totem, its triggered ability will trigger. A number of permanents equal to the amount of damage dealt will be sacrificed when the ability resolves. It doesn't matter if Phyrexian Totem isn't on the battlefield when the ability resolves, as long as Phyrexian Totem was a creature as it left the battlefield. If one of the permanents sacrificed is Phyrexian Totem itself, the requisite number of other permanents must still be sacrificed."
+          "text": "When damage is dealt to Phyrexian Totem, its triggered ability will trigger. A number of permanents equal to the amount of damage dealt will be sacrificed when the ability resolves. It doesn’t matter if Phyrexian Totem isn’t on the battlefield when the ability resolves, as long as Phyrexian Totem was a creature as it left the battlefield. If one of the permanents sacrificed is Phyrexian Totem itself, the requisite number of other permanents must still be sacrificed."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {B} to your mana pool.\n{2}{B}: Phyrexian Totem becomes a 5/5 black Horror artifact creature with trample until end of turn.\nWhenever Phyrexian Totem is dealt damage, if it's a creature, sacrifice that many permanents.",
@@ -32252,10 +28361,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32264,19 +28369,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32285,6 +28378,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "262",
       "multiverseid": 118880,
       "name": "Prismatic Lens",
       "number": "262",
@@ -32355,10 +28449,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32367,19 +28457,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32388,6 +28466,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "263",
       "multiverseid": 114921,
       "name": "Sarpadian Empires, Vol. VII",
       "number": "263",
@@ -32457,10 +28536,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32469,19 +28544,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32490,6 +28553,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "264",
       "multiverseid": 116724,
       "name": "Stuffy Doll",
       "number": "264",
@@ -32569,10 +28633,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32581,19 +28641,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32602,6 +28650,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "265",
       "multiverseid": 108931,
       "name": "Thunder Totem",
       "number": "265",
@@ -32614,7 +28663,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {W} to your mana pool.\n{1}{W}{W}: Thunder Totem becomes a 2/2 white Spirit artifact creature with flying and first strike until end of turn.",
@@ -32677,10 +28726,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32689,19 +28734,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32710,6 +28743,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "266",
       "multiverseid": 114919,
       "name": "Triskelavus",
       "number": "266",
@@ -32787,10 +28821,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32799,19 +28829,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32820,6 +28838,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "267",
       "multiverseid": 125866,
       "name": "Venser's Sliver",
       "number": "267",
@@ -32896,10 +28915,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -32908,19 +28923,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -32929,6 +28932,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "268",
       "multiverseid": 108809,
       "name": "Weatherseed Totem",
       "number": "268",
@@ -32941,11 +28945,11 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Weatherseed Totem will be returned to its owner's hand if it was a creature at the time it was put into a graveyard from the battlefield."
+          "text": "Weatherseed Totem will be returned to its owner’s hand if it was a creature at the time it was put into a graveyard from the battlefield."
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "{T}: Add {G} to your mana pool.\n{2}{G}{G}{G}: Weatherseed Totem becomes a 5/3 green Treefolk artifact creature with trample until end of turn.\nWhen Weatherseed Totem is put into a graveyard from the battlefield, if it was a creature, return this card to its owner's hand.",
@@ -33011,10 +29015,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33023,19 +29023,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33043,6 +29031,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "269",
       "multiverseid": 116725,
       "name": "Academy Ruins",
       "number": "269",
@@ -33119,10 +29108,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33131,19 +29116,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33151,6 +29124,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "270",
       "multiverseid": 108930,
       "name": "Calciform Pools",
       "number": "270",
@@ -33223,10 +29197,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33235,19 +29205,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33255,6 +29213,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "271",
       "multiverseid": 108817,
       "name": "Dreadship Reef",
       "number": "271",
@@ -33328,10 +29287,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33340,19 +29295,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33360,6 +29303,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "272",
       "multiverseid": 116733,
       "name": "Flagstones of Trokair",
       "number": "272",
@@ -33435,10 +29379,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33447,19 +29387,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33467,6 +29395,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "273",
       "multiverseid": 108796,
       "name": "Fungal Reaches",
       "number": "273",
@@ -33536,10 +29465,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33548,19 +29473,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33568,6 +29481,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "274",
       "multiverseid": 122094,
       "name": "Gemstone Caverns",
       "number": "274",
@@ -33584,15 +29498,15 @@
         },
         {
           "date": "2011-06-01",
-          "text": "Your \"opening hand\" is the hand of cards you decide to start the game with after taking any mulligans."
+          "text": "Your “opening hand” is the hand of cards you decide to start the game with after taking any mulligans."
         },
         {
           "date": "2011-06-01",
-          "text": "After all players have decided not to take any more mulligans, if the starting player has any cards that allow actions to be taken with them from a player's opening hand, that player may take the actions of any of those cards. The starting player repeats this, taking all actions he or she wishes to, one at a time. Then each other player in turn order may do the same. After each player has exercised his or her option to take actions from his or her opening hand, the first turn of the game begins."
+          "text": "After all players have decided not to take any more mulligans, if the starting player has any cards that allow actions to be taken with them from a player’s opening hand, that player may take the actions of any of those cards. The starting player repeats this, taking all actions he or she wishes to, one at a time. Then each other player in turn order may do the same. After each player has exercised his or her option to take actions from his or her opening hand, the first turn of the game begins."
         },
         {
           "date": "2013-07-01",
-          "text": "If multiple Gemstone Caverns are put onto the battlefield under a single player's control before the game begins, the \"legend rule\" won't put the extras into that player's graveyard until just before the first player gets priority during his or her first upkeep step. There's no opportunity to tap the extras for mana."
+          "text": "If multiple Gemstone Caverns are put onto the battlefield under a single player’s control before the game begins, the “legend rule” won’t put the extras into that player’s graveyard until just before the first player gets priority during his or her first upkeep step. There’s no opportunity to tap the extras for mana."
         }
       ],
       "supertypes": [
@@ -33661,10 +29575,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33673,19 +29583,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33693,6 +29591,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "275",
       "multiverseid": 113553,
       "name": "Kher Keep",
       "number": "275",
@@ -33769,10 +29668,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33781,19 +29676,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33801,6 +29684,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "276",
       "multiverseid": 108860,
       "name": "Molten Slagheap",
       "number": "276",
@@ -33875,10 +29759,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33887,19 +29767,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -33907,6 +29775,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "277",
       "multiverseid": 108839,
       "name": "Saltcrusted Steppe",
       "number": "277",
@@ -33977,10 +29846,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -33989,19 +29854,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -34009,6 +29862,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "278",
       "multiverseid": 114913,
       "name": "Swarmyard",
       "number": "278",
@@ -34078,10 +29932,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -34090,19 +29940,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -34110,6 +29948,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "279",
       "multiverseid": 118874,
       "name": "Terramorphic Expanse",
       "number": "279",
@@ -34194,10 +30033,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -34206,19 +30041,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -34226,6 +30049,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "280",
       "multiverseid": 116384,
       "name": "Urza's Factory",
       "number": "280",
@@ -34240,7 +30064,7 @@
       "rulings": [
         {
           "date": "2006-09-25",
-          "text": "Although Urza's Factory has the Urza's land type, it doesn't interact with Urza's Tower, Urza's Mine, or Urza's Power Plant."
+          "text": "Although Urza’s Factory has the Urza’s land type, it doesn’t interact with Urza’s Tower, Urza’s Mine, or Urza’s Power Plant."
         }
       ],
       "subtypes": [
@@ -34306,10 +30130,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -34318,19 +30138,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -34338,6 +30146,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "281",
       "multiverseid": 113543,
       "name": "Vesuva",
       "number": "281",
@@ -34355,11 +30164,11 @@
         },
         {
           "date": "2006-09-25",
-          "text": "If you don't choose a land on the battlefield, Vesuva enters the battlefield untapped as itself."
+          "text": "If you don’t choose a land on the battlefield, Vesuva enters the battlefield untapped as itself."
         },
         {
           "date": "2006-10-15",
-          "text": "Cornered Market won't prevent Vesuva from being played (unless there's a Vesuva on the battlefield copying nothing), since you play it before it becomes named something else."
+          "text": "Cornered Market won’t prevent Vesuva from being played (unless there’s a Vesuva on the battlefield copying nothing), since you play it before it becomes named something else."
         }
       ],
       "text": "You may have Vesuva enter the battlefield tapped as a copy of any land on the battlefield.",

--- a/json/VMA.json
+++ b/json/VMA.json
@@ -48,16 +48,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -105,16 +97,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -141,7 +125,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         }
       ],
       "text": "Take an extra turn after this one.",
@@ -168,16 +152,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -204,7 +180,7 @@
       "rulings": [
         {
           "date": "2013-07-01",
-          "text": "This card won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect."
+          "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
         }
       ],
       "text": "Each player shuffles his or her hand and graveyard into his or her library, then draws seven cards. (Then put Timetwister into its owner's graveyard.)",
@@ -225,16 +201,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -279,16 +247,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -333,16 +293,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -387,16 +339,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -441,16 +385,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -495,16 +431,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -552,10 +480,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -565,18 +489,6 @@
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -624,27 +536,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -695,23 +591,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -772,27 +652,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -816,7 +680,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If a player cycles a card during the end step, the creature that is exiled won't come back until the end of the next turn."
+          "text": "If a player cycles a card during the end step, the creature that is exiled won’t come back until the end of the next turn."
         },
         {
           "date": "2008-08-01",
@@ -847,23 +711,7 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Banned"
         },
         {
@@ -895,7 +743,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "This spell is not targeted, so cards which can't be targeted, such as a creature with protection from white, are both counted and valid choices for being sacrificed."
+          "text": "This spell is not targeted, so cards which can’t be targeted, such as a creature with protection from white, are both counted and valid choices for being sacrificed."
         },
         {
           "date": "2004-10-04",
@@ -930,27 +778,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -995,27 +827,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1066,27 +882,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1137,23 +937,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1201,15 +985,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -1261,19 +1037,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -1343,23 +1107,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1382,7 +1130,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "In a Two-Headed Giant game, the first ability triggers once during each team's upkeep."
+          "text": "In a Two-Headed Giant game, the first ability triggers once during each team’s upkeep."
         }
       ],
       "text": "At the beginning of each upkeep, put a strife counter on Crescendo of War.\nAttacking creatures get +1/+0 for each strife counter on Crescendo of War.\nBlocking creatures you control get +1/+0 for each strife counter on Crescendo of War.",
@@ -1409,27 +1157,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1455,7 +1187,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The two X's in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
+          "text": "The two X’s in the mana cost mean that you pay 2 mana (above the {2}{W}{W} base cost) for each token you want to create."
         },
         {
           "date": "2004-10-04",
@@ -1475,7 +1207,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         }
       ],
       "text": "Put X 4/4 white Angel creature tokens with flying onto the battlefield.\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle Decree of Justice, you may pay {X}. If you do, put X 1/1 white Soldier creature tokens onto the battlefield.",
@@ -1502,27 +1234,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1573,19 +1289,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -1636,19 +1344,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -1672,7 +1372,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The value of X is recalculated constantly, so this card's bonus varies as the number of cards in your hand varies."
+          "text": "The value of X is recalculated constantly, so this card’s bonus varies as the number of cards in your hand varies."
         }
       ],
       "subtypes": [
@@ -1702,27 +1402,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1748,7 +1432,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Plainscycling doesn't allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Plainscycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Plains card. After you find a Plains card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -1792,27 +1476,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1859,15 +1527,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -1917,27 +1577,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -1988,27 +1632,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2060,27 +1688,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2134,23 +1746,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2180,7 +1776,7 @@
       "rulings": [
         {
           "date": "2008-04-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "subtypes": [
@@ -2213,23 +1809,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2284,19 +1864,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -2328,7 +1900,7 @@
         },
         {
           "date": "2008-04-01",
-          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven't been printed in years."
+          "text": "Players may not rearrange the cards in their graveyards. This is a little-known rule because new cards that care about graveyard order haven’t been printed in years."
         },
         {
           "date": "2008-04-01",
@@ -2336,15 +1908,15 @@
         },
         {
           "date": "2008-04-01",
-          "text": "The last thing that happens to a resolving instant or sorcery spell is that it's put into its owner's graveyard. --Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
+          "text": "The last thing that happens to a resolving instant or sorcery spell is that it’s put into its owner’s graveyard. --Example: You cast Wrath of God. All creatures on the battlefield are destroyed. You arrange all the cards put into your graveyard this way in any order you want. The other players in the game do the same to the cards that are put into their graveyards. Then you put Wrath of God into your graveyard, on top of the other cards."
         },
         {
           "date": "2008-04-01",
-          "text": "Say you're the owner of both a permanent and an Aura that's attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma's Vengeance, for example), you decide the order they're put into your graveyard. If just the enchanted permanent is destroyed, it's put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
+          "text": "Say you’re the owner of both a permanent and an Aura that’s attached to it. If both the permanent and the Aura are destroyed at the same time (by Akroma’s Vengeance, for example), you decide the order they’re put into your graveyard. If just the enchanted permanent is destroyed, it’s put into your graveyard first. Then, after state-based actions are checked, the Aura (which is no longer attached to anything) is put into your graveyard on top of it."
         },
         {
           "date": "2008-04-01",
-          "text": "If you control Mistmoon Griffin when it goes to the graveyard, you exile the Griffin and return the top creature card from your graveyard to the battlefield. It doesn't matter whose graveyard the Griffin goes to."
+          "text": "If you control Mistmoon Griffin when it goes to the graveyard, you exile the Griffin and return the top creature card from your graveyard to the battlefield. It doesn’t matter whose graveyard the Griffin goes to."
         }
       ],
       "subtypes": [
@@ -2376,27 +1948,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2447,27 +2003,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2520,19 +2060,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -2576,27 +2108,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2665,27 +2181,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2738,15 +2238,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -2803,15 +2295,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -2865,27 +2349,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -2916,7 +2384,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         }
       ],
       "text": "You gain 6 life.\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle Renewed Faith, you may gain 2 life.",
@@ -2944,27 +2412,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3017,27 +2469,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3082,27 +2518,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3157,15 +2577,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -3220,15 +2632,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -3284,27 +2688,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3348,15 +2736,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -3412,27 +2792,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3483,27 +2847,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3547,7 +2895,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The amount of life that's gained is equal to the power of the targeted creature as it last existed on the battlefield."
+          "text": "The amount of life that’s gained is equal to the power of the targeted creature as it last existed on the battlefield."
         }
       ],
       "text": "Exile target creature. Its controller gains life equal to its power.",
@@ -3575,27 +2923,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3646,27 +2978,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3691,7 +3007,7 @@
       "rulings": [
         {
           "date": "2005-08-01",
-          "text": "A creature is \"enchanted\" if it has any Auras attached to it."
+          "text": "A creature is “enchanted” if it has any Auras attached to it."
         }
       ],
       "text": "Destroy all creatures that aren't enchanted. They can't be regenerated.",
@@ -3719,27 +3035,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3790,19 +3090,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -3853,27 +3141,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3901,7 +3173,7 @@
         },
         {
           "date": "2013-04-15",
-          "text": "Switching a creature's power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
+          "text": "Switching a creature’s power and toughness twice (or any even number of times) effectively returns the creature to the power and toughness it had before any switches."
         }
       ],
       "subtypes": [
@@ -3933,27 +3205,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -3976,15 +3232,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -4019,10 +3275,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -4032,18 +3284,6 @@
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4103,27 +3343,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4154,11 +3378,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
         }
       ],
       "text": "Tap up to four target creatures.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle Choking Tethers, you may tap target creature.",
@@ -4185,27 +3409,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4226,7 +3434,7 @@
         "VMA"
       ],
       "rarity": "Common",
-      "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Counter target spell unless its controller pays {1} for each card in your graveyard.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -4251,19 +3459,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -4313,15 +3513,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -4349,7 +3541,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can untap another player's lands."
+          "text": "You can untap another player’s lands."
         },
         {
           "date": "2004-10-04",
@@ -4393,23 +3585,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4473,10 +3649,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -4489,19 +3661,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4570,27 +3730,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4638,15 +3782,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -4701,27 +3837,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4782,23 +3902,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4822,15 +3926,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -4865,27 +3969,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -4932,16 +4020,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Urza Block",
@@ -4967,7 +4047,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can untap another player's lands."
+          "text": "You can untap another player’s lands."
         },
         {
           "date": "2004-10-04",
@@ -4998,27 +4078,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5042,7 +4106,7 @@
       "rulings": [
         {
           "date": "2007-05-01",
-          "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
+          "text": "The top card of your library isn’t in your hand, so you can’t suspend it, cycle it, discard it, or activate any of its activated abilities."
         },
         {
           "date": "2007-05-01",
@@ -5058,7 +4122,7 @@
         },
         {
           "date": "2007-05-01",
-          "text": "If the top card of your library changes while you're casting a spell or activating an ability, the new top card won't be revealed until you finish casting that spell or activating that ability."
+          "text": "If the top card of your library changes while you’re casting a spell or activating an ability, the new top card won’t be revealed until you finish casting that spell or activating that ability."
         }
       ],
       "text": "Play with the top card of your library revealed.\nYou may play the top card of your library.",
@@ -5086,28 +4150,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
         },
         {
           "format": "Masques Block",
           "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Banned"
         },
         {
           "format": "Vintage",
@@ -5153,23 +4201,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5225,28 +4257,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Modern",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -5274,55 +4290,11 @@
       "rulings": [
         {
           "date": "2010-03-01",
-          "text": "Jace, the Mind Sculptor is the first planeswalker with a loyalty ability that costs [0]. Activating this ability follows the same rules as activating any other planeswalker ability, though you'll neither put loyalty counters on Jace nor remove loyalty counters from Jace to do so."
+          "text": "Jace, the Mind Sculptor is the first planeswalker with a loyalty ability that costs [0]. Activating this ability follows the same rules as activating any other planeswalker ability, though you’ll neither put loyalty counters on Jace nor remove loyalty counters from Jace to do so."
         },
         {
           "date": "2010-03-01",
-          "text": "If you activate Jace's second ability, the two cards you put on top of your library may be any two cards from your hand. They don't have to be cards you drew with the ability."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are permanents. You can cast one at the time you could cast a sorcery. When your planeswalker spell resolves, it enters the battlefield under your control."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers are not creatures. Spells and abilities that affect creatures won’t affect them."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers have loyalty. A planeswalker enters the battlefield with a number of loyalty counters on it equal to the number printed in its lower right corner. Activating one of its abilities may cause it to gain or lose loyalty counters. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it. If it has no loyalty counters on it, it’s put into its owner’s graveyard as a state-based action."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers each have a number of activated abilities called “loyalty abilities.” You can activate a loyalty ability of a planeswalker you control only at the time you could cast a sorcery and only if you haven’t activated one of that planeswalker’s loyalty abilities yet that turn."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "The cost to activate a planeswalker’s loyalty ability is represented by a symbol with a number inside. Up-arrows contain positive numbers, such as “+1”; this means “Put one loyalty counter on this planeswalker.” Down-arrows contain negative numbers, such as “-7”; this means “Remove seven loyalty counters from this planeswalker.” A symbol with a “0” means “Put zero loyalty counters on this planeswalker.”"
-        },
-        {
-          "date": "2013-07-01",
-          "text": "You can’t activate a planeswalker’s ability with a negative loyalty cost unless the planeswalker has at least that many loyalty counters on it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "Planeswalkers can’t attack (unless an effect turns the planeswalker into a creature). However, they can be attacked. Each of your attacking creatures can attack your opponent or a planeswalker that player controls. You say which as you declare attackers."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If your planeswalkers are being attacked, you can block the attackers as normal."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a creature that’s attacking a planeswalker isn’t blocked, it’ll deal its combat damage to that planeswalker. Damage dealt to a planeswalker causes that many loyalty counters to be removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a source you control would deal noncombat damage to an opponent, you may have that source deal that damage to a planeswalker that opponent controls instead. For example, although you can’t target a planeswalker with Shock, you can target your opponent with Shock, and then as Shock resolves, choose to have Shock deal its 2 damage to one of your opponent’s planeswalkers. (You can’t split up that damage between different players and/or planeswalkers.) If you have Shock deal its damage to a planeswalker, two loyalty counters are removed from it."
-        },
-        {
-          "date": "2013-07-01",
-          "text": "If a player controls two or more planeswalkers that share a planeswalker type, that player chooses one of them and the rest are put into their owners’ graveyards as a state-based action."
+          "text": "If you activate Jace’s second ability, the two cards you put on top of your library may be any two cards from your hand. They don’t have to be cards you drew with the ability."
         }
       ],
       "subtypes": [
@@ -5353,27 +4325,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5430,15 +4386,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -5494,27 +4442,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5566,16 +4498,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -5598,15 +4522,15 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell \"can't be countered,\" it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
+          "text": "If the targeted spell “can’t be countered,” it remains on the stack. Mana Drain continues to resolve. At the beginning of your next main phase, the delayed triggered ability will still add the mana to your mana pool."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won't get any mana later."
+          "text": "If the targeted spell is an illegal target by the time Mana Drain resolves, Mana Drain is countered. You won’t get any mana later."
         },
         {
           "date": "2009-10-01",
-          "text": "Mana Drain's delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn's postcombat main phase."
+          "text": "Mana Drain’s delayed triggered ability will usually trigger at the beginning of your precombat main phase. However, if you cast Mana Drain during your precombat main phase or during your combat phase, its delayed triggered ability will trigger at the beginning of that turn’s postcombat main phase."
         }
       ],
       "text": "Counter target spell. At the beginning of your next main phase, add an amount of {C} to your mana pool equal to that spell's converted mana cost.",
@@ -5634,27 +4558,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5716,27 +4624,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5768,15 +4660,15 @@
         },
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -5807,15 +4699,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -5870,19 +4754,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -5942,27 +4814,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -5982,7 +4838,7 @@
         "VMA"
       ],
       "rarity": "Common",
-      "text": "Draw a card.\nMadness {U} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Draw a card.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "type": "Instant",
       "types": [
         "Instant"
@@ -6006,27 +4862,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6053,7 +4893,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "An ability that triggers when something \"attacks and isn't blocked\" triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
+          "text": "An ability that triggers when something “attacks and isn’t blocked” triggers in the declare blockers step after blockers are declared if (1) that creature is attacking and (2) no creatures are declared to block it. It will trigger even if that creature was put onto the battlefield attacking rather than having been declared as an attacker in the declare attackers step."
         }
       ],
       "subtypes": [
@@ -6084,15 +4924,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -6143,15 +4975,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -6184,7 +5008,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You can untap another player's lands."
+          "text": "You can untap another player’s lands."
         },
         {
           "date": "2004-10-04",
@@ -6219,19 +5043,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -6297,10 +5109,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -6313,19 +5121,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6371,7 +5167,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not \"tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
+          "text": "When this spell resolves, you either pay X mana or let your lands become tapped. The lands that become tapped are not “tapped for mana\". If you choose to pay, you may pay the X mana using whatever mana abilities you want to use."
         },
         {
           "date": "2010-03-01",
@@ -6403,27 +5199,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6467,15 +5247,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -6530,10 +5302,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -6542,19 +5310,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6606,23 +5362,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6647,7 +5387,7 @@
       "rulings": [
         {
           "date": "2008-10-01",
-          "text": "When the ability resolves, if one of the lands has become an illegal target (because it's no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
+          "text": "When the ability resolves, if one of the lands has become an illegal target (because it’s no longer on the battlefield, for example), you return the other one to your hand. If both of the lands have become illegal targets, the ability is countered. This has no effect on Sea Drake."
         }
       ],
       "subtypes": [
@@ -6679,23 +5419,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6748,27 +5472,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6819,23 +5527,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6886,27 +5578,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -6929,15 +5605,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -6973,15 +5649,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7042,15 +5710,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7105,15 +5765,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7169,27 +5821,11 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7234,15 +5870,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7279,15 +5907,15 @@
         },
         {
           "date": "2004-10-04",
-          "text": "When it changes forms, any \"enters the battlefield\" abilities of the card it \"copies\" do not trigger."
+          "text": "When it changes forms, any “enters the battlefield” abilities of the card it “copies” do not trigger."
         },
         {
           "date": "2004-10-04",
-          "text": "A copy of a Volrath's Shapeshifter will have the shapeshifting ability."
+          "text": "A copy of a Volrath’s Shapeshifter will have the shapeshifting ability."
         },
         {
           "date": "2004-10-04",
-          "text": "If the top card in your graveyard isn't a creature card (meaning a card with the type Creature, which may or may not have other types such as Artifact or Enchantment), then it's just a 0/1 blue creature. Older cards of type Summon are also Creature cards."
+          "text": "If the top card in your graveyard isn’t a creature card (meaning a card with the type Creature, which may or may not have other types such as Artifact or Enchantment), then it’s just a 0/1 blue creature. Older cards of type Summon are also Creature cards."
         },
         {
           "date": "2008-08-01",
@@ -7323,19 +5951,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7386,27 +6006,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7450,23 +6054,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7506,15 +6094,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Once the creature is returned to the battlefield, Animate Dead can't be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won't work."
+          "text": "Once the creature is returned to the battlefield, Animate Dead can’t be attached to anything other than it (unless Animate Dead somehow manages to put a different creature onto the battlefield). Attempting to move Animate Dead to another creature won’t work."
         },
         {
           "date": "2008-04-01",
-          "text": "If the creature card put onto the battlefield has Protection from Black (or anything that prevents this from legally being attached), this won't be able to attach to it. Then this will go to the graveyard as a State-Based Action, causing the creature to be sacrificed."
+          "text": "If the creature card put onto the battlefield has Protection from Black (or anything that prevents this from legally being attached), this won’t be able to attach to it. Then this will go to the graveyard as a State-Based Action, causing the creature to be sacrificed."
         },
         {
           "date": "2008-04-01",
-          "text": "A \"creature card\" is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
+          "text": "A “creature card” is any card with the type Creature, even if it has other types such as Artifact, Enchantment, or Land. Older cards of type Summon are also Creature cards."
         }
       ],
       "subtypes": [
@@ -7545,23 +6133,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7611,27 +6183,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7676,15 +6232,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7739,27 +6287,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7806,27 +6338,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -7870,15 +6386,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -7950,15 +6458,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -8002,23 +6502,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8074,10 +6558,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
@@ -8094,19 +6574,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8181,15 +6649,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -8245,27 +6705,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8314,15 +6758,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Banned"
         },
         {
@@ -8358,7 +6794,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "You don't reveal the card to your opponent."
+          "text": "You don’t reveal the card to your opponent."
         },
         {
           "date": "2004-10-04",
@@ -8389,19 +6825,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -8456,15 +6880,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -8519,27 +6935,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8590,23 +6990,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8653,19 +7037,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -8715,23 +7091,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8778,27 +7138,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8847,15 +7191,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -8911,27 +7247,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -8982,27 +7302,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9031,7 +7335,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The creatures which are sacrificed can't be regenerated."
+          "text": "The creatures which are sacrificed can’t be regenerated."
         },
         {
           "date": "2004-10-04",
@@ -9039,7 +7343,7 @@
         },
         {
           "date": "2013-09-20",
-          "text": "\"All cards he or she exiled this way\" refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren't returned to the battlefield."
+          "text": "“All cards he or she exiled this way” refers only to the cards exiled in the first part of the effect. If a replacement effect (such as Leyline of the Void) exiles any of the sacrificed creatures instead of putting them into the graveyard, those cards aren’t returned to the battlefield."
         }
       ],
       "text": "Each player exiles all creature cards from his or her graveyard, then sacrifices all creatures he or she controls, then puts all cards he or she exiled this way onto the battlefield.",
@@ -9067,15 +7371,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -9110,7 +7406,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "Pay half your life, rounded up: Lurking Evil becomes a 4/4 Horror creature with flying.",
@@ -9137,27 +7433,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9209,15 +7489,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -9261,28 +7533,12 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -9336,27 +7592,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9386,7 +7626,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, \"only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell's cost."
+          "text": "The generic X cost is still considered generic even if there is a requirement that a specific color be used for it. For example, “only black mana can be spent this way\". This distinction is important for effects which reduce the generic portion of a spell’s cost."
         },
         {
           "date": "2004-10-04",
@@ -9406,7 +7646,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If this card is sacrificed to pay part of a spell's cost, the cost reduction still applies."
+          "text": "If this card is sacrificed to pay part of a spell’s cost, the cost reduction still applies."
         }
       ],
       "subtypes": [
@@ -9437,23 +7677,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9531,23 +7755,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9601,15 +7809,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -9658,27 +7858,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -9730,15 +7914,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -9770,7 +7946,7 @@
       "rulings": [
         {
           "date": "2004-12-01",
-          "text": "You lose life equal to the converted mana cost of the card you're bringing back, so if you Reanimate Volrath's Shapeshifter, you lose three life, regardless of what the next card down is."
+          "text": "You lose life equal to the converted mana cost of the card you’re bringing back, so if you Reanimate Volrath’s Shapeshifter, you lose three life, regardless of what the next card down is."
         }
       ],
       "text": "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to its converted mana cost.",
@@ -9798,15 +7974,7 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -9835,7 +8003,7 @@
       "rulings": [
         {
           "date": "2013-04-15",
-          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you'll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
+          "text": "If you cast this as normal during your main phase, it will enter the battlefield and you’ll receive priority. If no abilities trigger because of this, you can activate its ability immediately, before any other player has a chance to remove it from the battlefield."
         }
       ],
       "text": "Sacrifice a creature, Return Recurring Nightmare to its owner's hand: Return target creature card from your graveyard to the battlefield. Activate this ability only any time you could cast a sorcery.",
@@ -9862,19 +8030,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -9928,15 +8084,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -9987,15 +8135,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -10049,15 +8189,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -10109,27 +8241,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10153,15 +8269,15 @@
       "rulings": [
         {
           "date": "2013-06-07",
-          "text": "The copies are put directly onto the stack. They aren't cast and won't be counted by other spells with storm cast later in the turn."
+          "text": "The copies are put directly onto the stack. They aren’t cast and won’t be counted by other spells with storm cast later in the turn."
         },
         {
           "date": "2013-06-07",
-          "text": "Spells cast from zones other than a player's hand and spells that were countered are counted by the storm ability."
+          "text": "Spells cast from zones other than a player’s hand and spells that were countered are counted by the storm ability."
         },
         {
           "date": "2013-06-07",
-          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won't affect the copies."
+          "text": "A copy of a spell can be countered like any other spell, but it must be countered individually. Countering a spell with storm won’t affect the copies."
         },
         {
           "date": "2013-06-07",
@@ -10196,19 +8312,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -10279,27 +8383,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10354,27 +8442,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10421,27 +8493,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10495,16 +8551,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Urza Block",
@@ -10552,16 +8600,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Urza Block",
@@ -10597,7 +8637,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If an effect asks you to discard a card, you can't \"discard\" something that is in your graveyard. Those cards are not in your hand. Thus, Cycling abilities of cards in the graveyard can't be activated."
+          "text": "If an effect asks you to discard a card, you can’t “discard” something that is in your graveyard. Those cards are not in your hand. Thus, Cycling abilities of cards in the graveyard can’t be activated."
         },
         {
           "date": "2004-10-04",
@@ -10605,11 +8645,11 @@
         },
         {
           "date": "2004-10-04",
-          "text": "If you play a card using Yawgmoth's Will and something triggers only when \"cast from your hand\", that something will not trigger. Such things trigger based on where the card came from."
+          "text": "If you play a card using Yawgmoth’s Will and something triggers only when “cast from your hand\", that something will not trigger. Such things trigger based on where the card came from."
         },
         {
           "date": "2004-10-04",
-          "text": "To \"play a card\" is to either cast a spell or to put a land onto the battlefield using the main phase special action."
+          "text": "To “play a card” is to either cast a spell or to put a land onto the battlefield using the main phase special action."
         },
         {
           "date": "2006-10-15",
@@ -10641,15 +8681,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -10699,23 +8731,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10767,15 +8783,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -10804,11 +8812,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The lands that will be destroyed aren't chosen until Burning of Xinye resolves."
+          "text": "The lands that will be destroyed aren’t chosen until Burning of Xinye resolves."
         },
         {
           "date": "2009-10-01",
-          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye's destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
+          "text": "A land with a regeneration shield on it will regenerate from Burning of Xinye’s destruction effect. However, the spell or ability that creates that shield must be cast or activated before Burning of Xinye starts to resolve."
         },
         {
           "date": "2009-10-01",
@@ -10844,27 +8852,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -10888,7 +8880,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Can't acquire the Ante cards. They are considered still \"in the game\" as are cards in the library and the graveyard."
+          "text": "Can’t acquire the Ante cards. They are considered still “in the game” as are cards in the library and the graveyard."
         },
         {
           "date": "2007-05-01",
@@ -10900,15 +8892,15 @@
         },
         {
           "date": "2007-09-16",
-          "text": "Can't acquire cards that are phased out."
+          "text": "Can’t acquire cards that are phased out."
         },
         {
           "date": "2009-10-01",
-          "text": "You can't acquire exiled cards because those cards are still in one of the game's zones."
+          "text": "You can’t acquire exiled cards because those cards are still in one of the game’s zones."
         },
         {
           "date": "2009-10-01",
-          "text": "In a sanctioned event, a card that's \"outside the game\" is one that's in your sideboard. In an unsanctioned event, you may choose any card from your collection."
+          "text": "In a sanctioned event, a card that’s “outside the game” is one that’s in your sideboard. In an unsanctioned event, you may choose any card from your collection."
         }
       ],
       "text": "You may choose a sorcery card you own from outside the game, reveal that card, and put it into your hand. Exile Burning Wish.",
@@ -10935,15 +8927,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -10980,11 +8964,11 @@
         },
         {
           "date": "2009-10-01",
-          "text": "As Chain Lightning resolves, the targeted player, or the controller of the targeted creature, may copy it. The copy has the same text, target, and color of the resolving spell, though the player who's copying it may choose a new target for it. Once that copy is created (or not), the resolving Chain Lightning has finished resolving and leaves the stack."
+          "text": "As Chain Lightning resolves, the targeted player, or the controller of the targeted creature, may copy it. The copy has the same text, target, and color of the resolving spell, though the player who’s copying it may choose a new target for it. Once that copy is created (or not), the resolving Chain Lightning has finished resolving and leaves the stack."
         },
         {
           "date": "2009-10-01",
-          "text": "If the targeted creature or player is an illegal target by the time Chain Lightning resolves, the spell is countered. It won't be copied."
+          "text": "If the targeted creature or player is an illegal target by the time Chain Lightning resolves, the spell is countered. It won’t be copied."
         }
       ],
       "text": "Chain Lightning deals 3 damage to target creature or player. Then that player or that creature's controller may pay {R}{R}. If the player does, he or she may copy this spell and may choose a new target for that copy.",
@@ -11011,23 +8995,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11052,7 +9020,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player's library this way, that player shuffles before revealing the top card of that library."
+          "text": "The owner of a token is the player under whose control the token was put onto the battlefield. If a token is shuffled into a player’s library this way, that player shuffles before revealing the top card of that library."
         },
         {
           "date": "2011-09-22",
@@ -11064,7 +9032,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If the revealed card is a permanent card but can't enter the battlefield (perhaps because it's an Aura with nothing to enchant), it remains on top of that library."
+          "text": "If the revealed card is a permanent card but can’t enter the battlefield (perhaps because it’s an Aura with nothing to enchant), it remains on top of that library."
         },
         {
           "date": "2011-09-22",
@@ -11095,27 +9063,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11144,7 +9096,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Mountaincycling doesn't allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Mountaincycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Mountain card. After you find a Mountain card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -11189,27 +9141,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11260,23 +9196,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11339,15 +9259,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -11396,27 +9308,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11465,27 +9361,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11547,15 +9427,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -11583,7 +9455,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It will be put into its owner's graveyard as soon as one of its abilities resolves that puts its toughness at zero (or less than the current amount of damage on it). This is a state-based action, so there is no way to activate its ability any more to increase its power further before it is put into the graveyard."
+          "text": "It will be put into its owner’s graveyard as soon as one of its abilities resolves that puts its toughness at zero (or less than the current amount of damage on it). This is a state-based action, so there is no way to activate its ability any more to increase its power further before it is put into the graveyard."
         }
       ],
       "subtypes": [
@@ -11616,15 +9488,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -11679,15 +9543,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -11743,15 +9599,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -11801,15 +9649,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -11862,27 +9702,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11933,23 +9757,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -11978,7 +9786,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type \"Goblin\". Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
+          "text": "A Goblin permanent card is an artifact, creature, land, and/or enchantment card with the creature type “Goblin\". Usually such cards will be creatures in addition to any other types, but they may be tribal instead. For example, you could put Boggart Shenanigans onto the battlefield with this effect."
         }
       ],
       "subtypes": [
@@ -12009,23 +9817,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12058,11 +9850,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         },
         {
           "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type “Summon Goblin” and “Summon Goblins” also count. You can’t search for cards that have Goblin in the name but don’t have the creature type Goblin."
         }
       ],
       "subtypes": [
@@ -12094,15 +9886,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -12155,10 +9939,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
@@ -12171,23 +9951,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -12245,27 +10009,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12318,15 +10066,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -12376,27 +10116,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12451,15 +10175,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -12510,27 +10226,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12575,15 +10275,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -12638,15 +10330,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -12702,27 +10386,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12775,27 +10443,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12847,15 +10499,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -12905,27 +10549,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -12970,27 +10598,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13035,27 +10647,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13108,19 +10704,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -13192,27 +10776,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13264,27 +10832,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13336,27 +10888,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13387,11 +10923,11 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         },
         {
           "date": "2008-10-01",
-          "text": "You can cycle this card even if there are no targets for the triggered ability. That's because the cycling ability itself has no targets."
+          "text": "You can cycle this card even if there are no targets for the triggered ability. That’s because the cycling ability itself has no targets."
         }
       ],
       "text": "Solar Blast deals 3 damage to target creature or player.\nCycling {1}{R}{R} ({1}{R}{R}, Discard this card: Draw a card.)\nWhen you cycle Solar Blast, you may have it deal 1 damage to target creature or player.",
@@ -13419,27 +10955,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13490,27 +11010,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13562,27 +11066,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13629,15 +11117,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -13691,16 +11171,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -13751,27 +11223,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13795,11 +11251,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "It is possible for the Dragon to leave the battlefield before its \"enters the battlefield\" trigger resolves. If this happens, then the \"leaves the battlefield\" trigger will have nothing to return and the \"enters the battlefield\" trigger's effects will be irreversible."
+          "text": "It is possible for the Dragon to leave the battlefield before its “enters the battlefield” trigger resolves. If this happens, then the “leaves the battlefield” trigger will have nothing to return and the “enters the battlefield” trigger’s effects will be irreversible."
         },
         {
           "date": "2005-08-01",
-          "text": "If an Aura is exiled this way, you can place it on any legal permanent when it returns. It doesn't have to go back to the same place. It can't be placed on a permanent that is entering the battlefield at the same time."
+          "text": "If an Aura is exiled this way, you can place it on any legal permanent when it returns. It doesn’t have to go back to the same place. It can’t be placed on a permanent that is entering the battlefield at the same time."
         }
       ],
       "subtypes": [
@@ -13831,27 +11287,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13874,7 +11314,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won't be sacrificed."
+          "text": "The sacrifice occurs only if you cast it using its own ability. If you cast it using some other effect (for instance, if it gained flash from Vedalken Orrery), then it won’t be sacrificed."
         }
       ],
       "subtypes": [
@@ -13905,27 +11345,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -13950,7 +11374,7 @@
       "subtypes": [
         "Wurm"
       ],
-      "text": "Trample\nMadness {2}{G} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "Trample\nMadness {2}{G} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "4",
       "type": "Creature — Wurm",
       "types": [
@@ -13975,27 +11399,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14022,13 +11430,13 @@
       "rulings": [
         {
           "date": "2006-02-01",
-          "text": "If this card's ability is activated by one player, then another player takes control of it on the same turn, the second player can't activate its ability that turn."
+          "text": "If this card’s ability is activated by one player, then another player takes control of it on the same turn, the second player can’t activate its ability that turn."
         }
       ],
       "subtypes": [
         "Lizard"
       ],
-      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)",
+      "text": "{1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
       "toughness": "1",
       "type": "Creature — Lizard",
       "types": [
@@ -14053,23 +11461,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14125,27 +11517,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14198,15 +11574,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -14255,23 +11623,7 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Banned"
         },
         {
@@ -14302,7 +11654,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can't pay life you don't have. In other words, you can't Channel yourself below zero life."
+          "text": "You can’t pay life you don’t have. In other words, you can’t Channel yourself below zero life."
         }
       ],
       "text": "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C} to your mana pool.",
@@ -14330,27 +11682,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14400,15 +11736,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -14470,27 +11798,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14542,15 +11854,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -14574,11 +11878,11 @@
       "rulings": [
         {
           "date": "2012-06-01",
-          "text": "Dreampod Druid's ability checks to see if it's enchanted at the beginning of each upkeep. If it's not, the ability won't trigger. If the ability triggers but Dreampod Druid isn't enchanted when that ability resolves, the ability will do nothing."
+          "text": "Dreampod Druid’s ability checks to see if it’s enchanted at the beginning of each upkeep. If it’s not, the ability won’t trigger. If the ability triggers but Dreampod Druid isn’t enchanted when that ability resolves, the ability will do nothing."
         },
         {
           "date": "2012-06-01",
-          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid's last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
+          "text": "Notably, if Dreampod Druid leaves the battlefield while its ability is on the stack, that ability will use Dreampod Druid’s last known information to determine whether or not it was enchanted. If it was enchanted when it left the battlefield, the ability will resolve and create a Saproling."
         }
       ],
       "subtypes": [
@@ -14611,27 +11915,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14657,7 +11945,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If cast targeting an opponent's creature, you get the Elephant when that creature goes to the graveyard."
+          "text": "If cast targeting an opponent’s creature, you get the Elephant when that creature goes to the graveyard."
         }
       ],
       "subtypes": [
@@ -14687,27 +11975,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14734,7 +12006,7 @@
       "rulings": [
         {
           "date": "2009-02-01",
-          "text": "Unlike the normal cycling ability, Forestcycling doesn't allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
+          "text": "Unlike the normal cycling ability, Forestcycling doesn’t allow you to draw a card. Instead, it lets you search your library for a Forest card. After you find a Forest card in your library, you reveal it, put it into your hand, then shuffle your library."
         },
         {
           "date": "2009-02-01",
@@ -14779,27 +12051,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14827,7 +12083,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+          "text": "In multiplayer games you can choose a different player’s creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
         },
         {
           "date": "2004-10-04",
@@ -14866,23 +12122,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -14907,11 +12147,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being \"cast\" or \"played\"."
+          "text": "The cards are put onto the battlefield and will not trigger effects which trigger on such cards being “cast” or “played\"."
         },
         {
           "date": "2004-10-04",
-          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn't end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
+          "text": "In a game of N players, the process ends when all N players in sequence (starting with you) choose not to put a card onto the battlefield. It doesn’t end the first time a player chooses not to put a card onto the battlefield. If a player chooses not to put a card onto the battlefield but the process continues, that player may put a card onto the battlefield the next time the process gets around to him or her."
         },
         {
           "date": "2004-10-04",
@@ -14923,7 +12163,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "A \"permanent card\" is a card that would be a permanent once it's on the battlefield. Specifically, it's an artifact, creature, enchantment, land, or planeswalker card."
+          "text": "A “permanent card” is a card that would be a permanent once it’s on the battlefield. Specifically, it’s an artifact, creature, enchantment, land, or planeswalker card."
         }
       ],
       "text": "Starting with you, each player may put a permanent card from his or her hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.",
@@ -14950,16 +12190,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -14988,11 +12220,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You take damage when you play a land using the \"play a land\" action. Such an action can be your regular \"play a land\", one enabled by Fastbond, or ones enabled through other effects."
+          "text": "You take damage when you play a land using the “play a land” action. Such an action can be your regular “play a land\", one enabled by Fastbond, or ones enabled through other effects."
         },
         {
           "date": "2004-10-04",
-          "text": "You do not take damage when you \"put a land onto the battlefield\" through the effect of a spell or ability."
+          "text": "You do not take damage when you “put a land onto the battlefield” through the effect of a spell or ability."
         }
       ],
       "text": "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, Fastbond deals 1 damage to you.",
@@ -15020,27 +12252,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15094,15 +12310,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -15154,27 +12362,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15221,11 +12413,11 @@
       "layout": "normal",
       "legalities": [
         {
-          "format": "Commander",
+          "format": "Battle for Zendikar Block",
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
+          "format": "Commander",
           "legality": "Legal"
         },
         {
@@ -15241,23 +12433,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
           "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Standard",
           "legality": "Legal"
         },
         {
@@ -15307,27 +12483,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15376,27 +12536,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15447,15 +12591,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Banned"
         },
         {
@@ -15518,27 +12654,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15587,27 +12707,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15646,7 +12750,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you'll draw a card."
+          "text": "The cycling ability and the triggered ability are separate. If the triggered ability is countered (with Stifle, for example, or if all its targets have become illegal), the cycling ability will still resolve and you’ll draw a card."
         }
       ],
       "subtypes": [
@@ -15678,27 +12782,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15749,27 +12837,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15799,7 +12871,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         },
         {
           "date": "2008-08-01",
@@ -15830,15 +12902,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -15895,27 +12959,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -15959,16 +13007,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Tempest Block",
@@ -16000,7 +13040,7 @@
         },
         {
           "date": "2009-10-01",
-          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can't be targeted by this ability unless it's true, and the ability will be countered on resolution if it's no longer true at that time."
+          "text": "The targeted player controlling more creatures than the current player is a part of the targeting requirement. A player can’t be targeted by this ability unless it’s true, and the ability will be countered on resolution if it’s no longer true at that time."
         }
       ],
       "text": "At the beginning of each player's upkeep, that player chooses target player who controls more creatures than he or she does and is his or her opponent. The first player may reveal cards from the top of his or her library until he or she reveals a creature card. If he or she does, that player puts that card onto the battlefield and all other cards revealed this way into his or her graveyard.",
@@ -16027,27 +13067,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16097,19 +13121,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -16165,19 +13177,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -16237,23 +13237,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16305,27 +13289,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16370,15 +13338,7 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -16436,19 +13396,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -16499,27 +13451,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16572,15 +13508,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -16640,27 +13568,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16704,16 +13616,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Tempest Block",
@@ -16742,7 +13646,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         }
       ],
       "text": "{G}, Discard a creature card: Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.",
@@ -16769,23 +13673,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16824,7 +13712,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "This will count as 2 draws for anything that affects \"drawn cards\"."
+          "text": "This will count as 2 draws for anything that affects “drawn cards\"."
         },
         {
           "date": "2004-10-04",
@@ -16832,7 +13720,7 @@
         },
         {
           "date": "2007-09-16",
-          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library's ability still happens. If you've actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven't actually drawn any cards that turn, the rest of the ability has no effect."
+          "text": "If you choose to draw two cards, then replace one or more of those draws with some other effect, the rest of Sylvan Library’s ability still happens. If you’ve actually drawn only one card that turn, you must choose that card and either pay 4 life or put it on top of your library. If you haven’t actually drawn any cards that turn, the rest of the ability has no effect."
         },
         {
           "date": "2013-04-15",
@@ -16864,27 +13752,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -16935,27 +13807,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17006,23 +13862,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17068,27 +13908,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17140,23 +13964,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17214,27 +14022,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17287,27 +14079,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17360,23 +14136,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17430,23 +14190,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17471,7 +14215,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "While Basandra, Battle Seraph is on the battlefield, players can't cast any spells during the combat phase, including permanent spells with flash."
+          "text": "While Basandra, Battle Seraph is on the battlefield, players can’t cast any spells during the combat phase, including permanent spells with flash."
         },
         {
           "date": "2011-09-22",
@@ -17479,7 +14223,7 @@
         },
         {
           "date": "2011-09-22",
-          "text": "If, during a player's declare attackers step, a creature is tapped, is affected by a spell or ability that says it can't attack, or hasn't been under that player's control continuously since the turn began (and doesn't have haste), then it doesn't attack. If there's a cost associated with having a creature attack, the player isn't forced to pay that cost, so it doesn't have to attack in that case either."
+          "text": "If, during a player’s declare attackers step, a creature is tapped, is affected by a spell or ability that says it can’t attack, or hasn’t been under that player’s control continuously since the turn began (and doesn’t have haste), then it doesn’t attack. If there’s a cost associated with having a creature attack, the player isn’t forced to pay that cost, so it doesn’t have to attack in that case either."
         }
       ],
       "subtypes": [
@@ -17515,27 +14259,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17588,19 +14316,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -17668,19 +14384,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -17748,19 +14452,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -17866,27 +14558,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -17936,19 +14612,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -18005,23 +14669,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18047,7 +14695,7 @@
       "rulings": [
         {
           "date": "2011-09-22",
-          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric's ability to trigger. The creature's controller chooses whether to draw a card."
+          "text": "A creature controlled by an opponent that deals combat damage to another opponent will cause Edric’s ability to trigger. The creature’s controller chooses whether to draw a card."
         },
         {
           "date": "2011-09-22",
@@ -18089,27 +14737,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18162,27 +14794,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18205,7 +14821,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "The tokens are named \"Goblin Soldier\" and have the creature types \"Goblin\" and \"Soldier\"."
+          "text": "The tokens are named “Goblin Soldier” and have the creature types “Goblin” and “Soldier\"."
         }
       ],
       "text": "{2}, Sacrifice a land: Put two 1/1 red and white Goblin Soldier creature tokens onto the battlefield.",
@@ -18234,19 +14850,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -18311,19 +14915,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -18399,19 +14991,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -18496,27 +15076,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18565,27 +15129,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18637,27 +15185,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18704,19 +15236,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -18744,7 +15264,7 @@
         },
         {
           "date": "2014-05-29",
-          "text": "If you activate Selvala’s ability while casting a spell, and you discover you can't produce enough mana to pay that spell’s costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala’s ability can't be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
+          "text": "If you activate Selvala’s ability while casting a spell, and you discover you can’t produce enough mana to pay that spell’s costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala’s ability can’t be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."
         },
         {
           "date": "2014-05-29",
@@ -18785,27 +15305,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18862,27 +15366,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18928,23 +15416,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -18980,7 +15452,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "It determines the land's controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land's last controller before it left is used."
+          "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
         }
       ],
       "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
@@ -19002,19 +15474,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -19041,7 +15505,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "text": "{0}: Tap all lands you control. Chimeric Idol becomes a 3/3 Turtle artifact creature until end of turn.",
@@ -19062,15 +15526,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -19119,19 +15575,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
           "legality": "Legal"
         },
         {
@@ -19191,15 +15635,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -19228,7 +15664,7 @@
       "rulings": [
         {
           "date": "2008-08-01",
-          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren't any). Since the named card wasn't revealed, no damage is dealt."
+          "text": "If you have no cards in hand, you still have to name a card. Then you fail to reveal one (since there aren’t any). Since the named card wasn’t revealed, no damage is dealt."
         }
       ],
       "text": "{3}, {T}: Name a card. Reveal a card at random from your hand. If it's the named card, Cursed Scroll deals 2 damage to target creature or player.",
@@ -19250,15 +15686,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -19307,23 +15735,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19350,7 +15762,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If you have four or fewer cards in your hand when Ivory Tower's ability resolves, the ability has no effect."
+          "text": "If you have four or fewer cards in your hand when Ivory Tower’s ability resolves, the ability has no effect."
         }
       ],
       "text": "At the beginning of your upkeep, you gain X life, where X is the number of cards in your hand minus 4.",
@@ -19371,23 +15783,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19422,7 +15818,7 @@
         },
         {
           "date": "2008-08-01",
-          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn't matter how long the permanent has been a creature."
+          "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of his or her most recent turn. It doesn’t matter how long the permanent has been a creature."
         }
       ],
       "subtypes": [
@@ -19452,27 +15848,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19517,23 +15897,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Banned"
         },
         {
@@ -19573,27 +15937,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19632,16 +15980,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -19686,23 +16026,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19752,24 +16076,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
         },
         {
           "format": "Urza Block",
@@ -19797,7 +16105,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can't look at the cards you exiled until they return to your hand."
+          "text": "You can’t look at the cards you exiled until they return to your hand."
         }
       ],
       "text": "{T}, Sacrifice Memory Jar: Each player exiles all cards from his or her hand face down and draws seven cards. At the beginning of the next end step, each player discards his or her hand and returns to his or her hand each card he or she exiled this way.",
@@ -19818,23 +16126,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -19873,7 +16165,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "The destruction of the Disk is not a sacrifice. It is destroyed as part of the resolution if it is still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it won't be destroyed by its ability."
+          "text": "The destruction of the Disk is not a sacrifice. It is destroyed as part of the resolution if it is still on the battlefield. If an effect gives Nevinyrral’s Disk indestructible or regenerates it, it won’t be destroyed by its ability."
         }
       ],
       "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
@@ -19895,19 +16187,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -19935,7 +16219,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder texts."
+          "text": "Activated abilities contain a colon. They’re generally written “[Cost]: [Effect].” Some keywords are activated abilities and will have colons in their reminder texts."
         },
         {
           "date": "2013-07-01",
@@ -19943,7 +16227,7 @@
         },
         {
           "date": "2013-07-01",
-          "text": "This effect does not prevent triggered abilities from triggering and it doesn't stop the effects of static abilities."
+          "text": "This effect does not prevent triggered abilities from triggering and it doesn’t stop the effects of static abilities."
         }
       ],
       "text": "Activated abilities of artifacts can't be activated.",
@@ -19965,27 +16249,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20028,15 +16296,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -20079,10 +16339,6 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
         },
@@ -20092,18 +16348,6 @@
         },
         {
           "format": "Modern",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Banned"
         },
         {
@@ -20148,15 +16392,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -20210,23 +16446,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Banned"
         },
         {
@@ -20277,15 +16497,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -20334,23 +16546,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20376,7 +16572,7 @@
       "rulings": [
         {
           "date": "2009-10-01",
-          "text": "You get the mana whether you want it or not. If you don't spend it, it will disappear at the end of the current step (or phase)."
+          "text": "You get the mana whether you want it or not. If you don’t spend it, it will disappear at the end of the current step (or phase)."
         }
       ],
       "subtypes": [
@@ -20402,15 +16598,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -20459,16 +16647,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -20496,7 +16676,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "If multiple \"extra turn\" effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
+          "text": "If multiple “extra turn” effects resolve in the same turn, take them in the reverse of the order that the effects resolved."
         },
         {
           "date": "2008-10-01",
@@ -20526,27 +16706,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20591,15 +16755,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -20641,27 +16797,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20683,7 +16823,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         }
       ],
       "text": "Bad River enters the battlefield tapped.\n{T}, Sacrifice Bad River: Search your library for an Island or Swamp card and put it onto the battlefield. Then shuffle your library.",
@@ -20707,23 +16847,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20752,7 +16876,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Land type changing effects that change a dual land's land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
+          "text": "Land type changing effects that change a dual land’s land type will remove the old land types completely. Text-changing effects that just change one of the two land types will leave the other type unaffected."
         },
         {
           "date": "2004-10-04",
@@ -20764,7 +16888,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20791,27 +16915,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -20865,15 +16973,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -20906,7 +17006,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -20930,16 +17030,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -20962,7 +17054,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can't cast spells or activate mana abilities before discarding the extra cards."
+          "text": "You can’t cast spells or activate mana abilities before discarding the extra cards."
         }
       ],
       "text": "{T}: Draw two cards, then discard three cards.",
@@ -20986,15 +17078,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -21035,27 +17119,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21078,7 +17146,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         }
       ],
       "text": "Flood Plain enters the battlefield tapped.\n{T}, Sacrifice Flood Plain: Search your library for a Plains or Island card and put it onto the battlefield. Then shuffle your library.",
@@ -21101,27 +17169,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21170,27 +17222,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21226,27 +17262,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21292,27 +17312,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Invasion Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21354,27 +17358,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21421,27 +17409,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Legal"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21489,16 +17461,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -21544,27 +17508,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21611,16 +17559,8 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Vintage",
@@ -21643,11 +17583,11 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "You can spend the mana on costs on the spell's text."
+          "text": "You can spend the mana on costs on the spell’s text."
         },
         {
           "date": "2004-10-04",
-          "text": "The mana can't be used to pay Echo costs."
+          "text": "The mana can’t be used to pay Echo costs."
         },
         {
           "date": "2004-10-04",
@@ -21675,27 +17615,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21741,15 +17665,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -21794,15 +17710,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -21835,7 +17743,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -21859,27 +17767,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -21902,7 +17794,7 @@
       "rulings": [
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         }
       ],
       "text": "Rocky Tar Pit enters the battlefield tapped.\n{T}, Sacrifice Rocky Tar Pit: Search your library for a Swamp or Mountain card and put it onto the battlefield. Then shuffle your library.",
@@ -21926,15 +17818,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -21979,23 +17863,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22028,7 +17896,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22056,15 +17924,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -22109,15 +17969,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -22150,7 +18002,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22177,27 +18029,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22251,15 +18087,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -22301,23 +18129,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Banned"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Banned"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Banned"
         },
         {
@@ -22362,23 +18174,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22411,7 +18207,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22435,27 +18231,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Ice Age Block",
           "legality": "Banned"
         },
         {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22484,7 +18264,7 @@
         },
         {
           "date": "2004-10-04",
-          "text": "Because the \"search\" requires you to find a card with certain characteristics, you don't have to find the card if you don't want to."
+          "text": "Because the “search” requires you to find a card with certain characteristics, you don’t have to find the card if you don’t want to."
         }
       ],
       "text": "Thawing Glaciers enters the battlefield tapped.\n{1}, {T}: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Return Thawing Glaciers to its owner's hand at the beginning of the next cleanup step.",
@@ -22508,16 +18288,8 @@
           "legality": "Banned"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Banned"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
         },
         {
           "format": "Urza Block",
@@ -22563,27 +18335,11 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
           "legality": "Legal"
         },
         {
           "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22636,15 +18392,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -22677,7 +18425,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22705,23 +18453,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22754,7 +18486,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22782,23 +18514,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
           "legality": "Legal"
         },
         {
@@ -22831,7 +18547,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22859,15 +18575,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {
@@ -22899,7 +18607,7 @@
         },
         {
           "date": "2008-10-01",
-          "text": "This has basic land types, but it isn't a basic land. Things that affect basic lands don't affect it. Things that affect basic land types do."
+          "text": "This has basic land types, but it isn’t a basic land. Things that affect basic lands don’t affect it. Things that affect basic land types do."
         }
       ],
       "subtypes": [
@@ -22927,15 +18635,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
           "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
           "legality": "Legal"
         },
         {


### PR DESCRIPTION
This fixes #147.

As per Gatherer, these are the sets that have madness:

Vintage Masters VMA
Torment TOR
Duel Decks Garruk vs Lilana DDD / DD3
Planar Chaos PLC
Times Spiral TSP/TSB
Future Sight FUT
Shadows of Innistrad SOI