### PR TITLE
Fix Clash Pack - Hero's Downfall collector number

### DIFF
--- a/json/CPK.json
+++ b/json/CPK.json
@@ -379,7 +379,7 @@
       ],
       "manaCost": "{1}{B}{B}",
       "name": "Hero's Downfall",
-      "number": "2",
+      "number": "8",
       "printings": [
         "THS",
         "CPK"


### PR DESCRIPTION
Hero's Downfall in the Clash Pack set has "2" as its number, which is shared with Fated Intervention.

According to magiccards.info [here](http://magiccards.info/query?q=e%3Aclash%2Fen&v=list&s=issue), Hero's Downfall should have 8 as its number instead.